### PR TITLE
Patches for cc_patch1 complete

### DIFF
--- a/character_creation_package/character_creation/models/npc_factory.py
+++ b/character_creation_package/character_creation/models/npc_factory.py
@@ -115,7 +115,8 @@ def generate_npc(
         class_catalog
     )  # dict: {id, grants_stats, grants_abilities, ...}
 
-    trait_names = list(trait_catalog.keys())
+    # trait_catalog is a mapping with key 'traits' -> dict of trait_id -> def
+    trait_names = list(trait_catalog.get("traits", {}).keys())
     max_traits = min(len(trait_names), 2)
     num_traits = random.randint(0, max_traits)
     chosen_trait_names = random.sample(trait_names, k=num_traits)
@@ -139,22 +140,9 @@ def generate_npc(
         resources=resources,
     )
 
-    # 5) Apply class: stats and abilities
-    for stat, amt in starter_class.get("grants_stats", {}).items():
-        _add_stat_value(character, stat, amt)
-
-    _add_abilities(getattr(character, "abilities", None), starter_class.get("grants_abilities", []))
-    if hasattr(character, "classes"):
-        _append_collection(character.classes, starter_class)
-
-    # 6) Apply traits
-    for trait_id in chosen_trait_names:
-        trait = trait_catalog[trait_id]
-        for stat, amt in trait.get("grants_stats", {}).items():
-            _add_stat_value(character, stat, amt)
-        _add_abilities(getattr(character, "abilities", None), trait.get("grants_abilities", []))
-        if hasattr(character, "traits"):
-            _append_collection(character.traits, trait)
+    # 5) Apply class and traits via Character API (IDs only, effects inside)
+    character.add_class(starter_class)
+    character.add_traits(chosen_trait_names, trait_catalog)
 
     # 7) Roll random appearance values (override defaults where appropriate)
     for field_name, field_info in appearance_fields.items():

--- a/character_creation_package/character_creation/ui/cli/wizard.py
+++ b/character_creation_package/character_creation/ui/cli/wizard.py
@@ -54,8 +54,8 @@ def run_wizard(loaders_dict: dict):
     appearance_fields = loaders_dict["appearance_fields"]
     appearance_defaults = loaders_dict.get("appearance_defaults", {})
     resources = loaders_dict["resources"]
-    class_catalog = loaders_dict["classes_loader"]
-    trait_catalog = loaders_dict["traits_loader"]
+    class_catalog = loaders_dict["class_catalog"]
+    trait_catalog = loaders_dict["trait_catalog"]
     starting_classes = available_starting_classes(stat_tmpl, class_catalog)
     class_def = choose_starting_class(starting_classes)
     traits = choose_traits(trait_catalog)
@@ -63,5 +63,6 @@ def run_wizard(loaders_dict: dict):
         name, stat_tmpl, slot_tmpl, appearance_fields, appearance_defaults, resources
     )
     character.add_class(class_def)
-    character.add_traits(traits)
+    # Apply trait effects and store IDs only
+    character.add_traits(traits, trait_catalog)
     return character

--- a/character_creation_package/character_creation/ui/textual/state.py
+++ b/character_creation_package/character_creation/ui/textual/state.py
@@ -63,7 +63,7 @@ def build_character_from_selections(
 
     # Validate trait ids against catalog and apply
     valid_trait_ids = [tid for tid in sel.trait_ids if tid in trait_catalog.get("traits", {})]
-    hero.add_traits(valid_trait_ids)
+    hero.add_traits(valid_trait_ids, trait_catalog)
 
     return hero
 

--- a/character_creation_package/scripts/create_character.py
+++ b/character_creation_package/scripts/create_character.py
@@ -38,8 +38,8 @@ def main() -> None:
             "appearance_fields": fields,
             "appearance_defaults": defaults,
             "resources": resources,
-            "classes_loader": class_catalog,
-            "traits_loader": trait_catalog,
+            "class_catalog": class_catalog,
+            "trait_catalog": trait_catalog,
         }
     )
 

--- a/character_creation_package/tests/test_character_yaml_integration.py
+++ b/character_creation_package/tests/test_character_yaml_integration.py
@@ -71,8 +71,8 @@ def test_run_wizard_full_flow(monkeypatch, tmp_path):
             DATA_DIR / "appearance" / "defaults.yaml"
         ),
         "resources": resources_loader.load_resources(DATA_DIR / "resources.yaml"),
-        "classes_loader": classes_loader.load_class_catalog(DATA_DIR / "classes.yaml"),
-        "traits_loader": traits_loader.load_trait_catalog(DATA_DIR / "traits.yaml"),
+        "class_catalog": classes_loader.load_class_catalog(DATA_DIR / "classes.yaml"),
+        "trait_catalog": traits_loader.load_trait_catalog(DATA_DIR / "traits.yaml"),
     }
 
     inputs = iter(["HeroName", "1", "brave, lucky", ""])

--- a/character_creation_package/tests/test_npc_generation.py
+++ b/character_creation_package/tests/test_npc_generation.py
@@ -42,8 +42,8 @@ def class_catalog(data_path: Path):
 
 @pytest.fixture(scope="module")
 def trait_catalog(data_path: Path):
-    # The YAML file has a root key 'traits', so we need to access it.
-    return yaml_utils.load_yaml(data_path / "traits.yaml").get("traits", {})
+    # Return the full trait catalog dict with key 'traits' for ID lookup
+    return yaml_utils.load_yaml(data_path / "traits.yaml")
 
 
 @pytest.fixture(scope="module")

--- a/character_creation_package/tests/test_wizard_smoke.py
+++ b/character_creation_package/tests/test_wizard_smoke.py
@@ -15,14 +15,14 @@ DATA_ROOT = Path(__file__).parents[2] / "character_creation_package" / "characte
 @pytest.fixture
 def loaders_dict():
     return {
-        "stats_loader": stats_loader.load_stat_template(DATA_ROOT / "stats" / "stats.yaml"),
-        "classes_loader": classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml"),
-        "traits_loader": traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml"),
-        "slots_loader": slots_loader.load_slot_template(DATA_ROOT / "slots.yaml"),
-        "fields": appearance_loader.load_appearance_fields(
+        "stat_tmpl": stats_loader.load_stat_template(DATA_ROOT / "stats" / "stats.yaml"),
+        "class_catalog": classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml"),
+        "trait_catalog": traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml"),
+        "slot_tmpl": slots_loader.load_slot_template(DATA_ROOT / "slots.yaml"),
+        "appearance_fields": appearance_loader.load_appearance_fields(
             DATA_ROOT / "appearance" / "fields.yaml"
         ),
-        "defaults": appearance_loader.load_appearance_defaults(
+        "appearance_defaults": appearance_loader.load_appearance_defaults(
             DATA_ROOT / "appearance" / "defaults.yaml"
         ),
         "resources": resources_loader.load_resources(DATA_ROOT / "resources.yaml"),
@@ -41,43 +41,19 @@ def test_run_wizard_smoke(monkeypatch, loaders_dict):
     )
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
-    # Patch run_wizard to pass all required args
-    from character_creation.ui.cli import wizard
+    from character_creation.ui.cli.wizard import run_wizard
 
-    def patched_run_wizard(loaders_dict):
-        name = wizard.ask_name()
-        stat_tmpl = loaders_dict["stats_loader"]
-        class_catalog = loaders_dict["classes_loader"]
-        trait_catalog = loaders_dict["traits_loader"]
-        slot_tmpl = loaders_dict["slots_loader"]
-        fields = loaders_dict["fields"]
-        defaults = loaders_dict["defaults"]
-        resources = loaders_dict["resources"]
-        starting_classes = wizard.available_starting_classes(stat_tmpl, class_catalog)
-        class_def = wizard.choose_starting_class(starting_classes)
-        traits = wizard.choose_traits(trait_catalog)
-        character = wizard.create_new_character(
-            name=name,
-            stat_tmpl=stat_tmpl,
-            slot_tmpl=slot_tmpl,
-            appearance_fields=fields,
-            appearance_defaults=defaults,
-            resources=resources,
-        )
-        character.add_class(class_def)
-        character.add_traits(traits)
-        return character
-
-    hero = patched_run_wizard(loaders_dict)
+    hero = run_wizard(loaders_dict)
     assert hero.name == "TestHero"
-    assert "brave" in getattr(hero, "traits", []) or "brave" in getattr(hero, "trait_ids", [])
-    starting_classes = loaders_dict["classes_loader"].get("classes", [])
+    assert "brave" in getattr(hero, "traits", [])
+    starting_classes = loaders_dict["class_catalog"].get("classes", [])
     first_class_id = starting_classes[0].get("id")
-    applied_class_ids = getattr(hero, "class_ids", [])
-    if not applied_class_ids:
-        classes = getattr(hero, "classes", [])
-        if classes and isinstance(classes[0], dict):
-            applied_class_ids = [c.get("id") for c in classes]
-        else:
-            applied_class_ids = classes  # assume list of ids
-    assert first_class_id in applied_class_ids
+    assert first_class_id in getattr(hero, "classes", [])
+
+    # If trait data includes grants, ensure they took effect where possible
+    brave_def = loaders_dict["trait_catalog"].get("traits", {}).get("brave", {})
+    grants_stats = brave_def.get("grants_stats", {})
+    for stat_key in grants_stats.keys():
+        assert hero.stats.get(stat_key, 0) >= grants_stats[stat_key]
+    for ability in brave_def.get("grants_abilities", []):
+        assert ability in hero.abilities


### PR DESCRIPTION
Patches for the following prompt:

ENVIRONMENT
Use the “worldseed” Python environment / interpreter for all indexing, analysis, and execution (not “base”).

SYSTEM / ROLE
You are an expert Python game-systems engineer. Follow Black/Ruff style, Python 3.12, pytest. Make minimal, surgical edits. Do not rename or move files unless instructed.

PROJECT CONTEXT
This repo (character_creation_package) is a YAML-driven character creation system.
Key areas:
- character_creation/models/character.py (Character model: stats, traits, classes, equip, refresh_derived)
- character_creation/models/factory.py (create_new_character)
- character_creation/models/npc_factory.py (NPC generator)
- character_creation/ui/cli/wizard.py and scripts/create_character.py (CLI wizard flow)
- loaders under character_creation/loaders (stats, classes, traits, slots, appearance, items, etc.)
- tests/ (pytest suite)
- Textual TUI exists but out of scope beyond label lookups

PHASE GOAL (cc_patch_1)
Core consistency patch to prep for Races/Appearance phases:

A) Wizard data keys: caller → wizard must match (no monkeypatching).
B) Trait selection applies real effects (stats/abilities), with dedupe.
C) Character stores class/trait **IDs only** (no dicts), consistently PC/NPC.
D) NPC factory uses add_class/add_traits (no manual dict appends or duplicate logic).
E) After derived recompute, ensure stats["HP"] and stats["Mana"] exist as dicts {base,current} synced to hero.hp/mana.
F) Tests reflect the above and run green.

FILES TO MODIFY (exact expectations)

1) scripts/create_character.py
- FIX: The dict passed to wizard.run_wizard must use these exact keys:
  stat_tmpl, slot_tmpl, appearance_fields, appearance_defaults, resources, class_catalog, trait_catalog
- Remove/rename any mismatched keys like "stats_loader", "fields", "defaults".
- Keep behavior: load data, run wizard, confirm save path, hero.to_json, print success.

2) character_creation/ui/cli/wizard.py
- Ensure run_wizard(loaders_dict) expects the EXACT keys above.
- After building the base Character, apply class and **apply trait effects**:
  - hero.add_class(chosen_class_def) (existing behavior)
  - hero.add_traits(selected_trait_ids, trait_catalog)  # NEW: pass catalog so effects apply
- ask_name() should loop until non-empty (if already implemented, keep it).

3) character_creation/models/character.py
- Update add_traits to:
  def add_traits(self, trait_ids: list[str], trait_catalog: dict | None = None) -> None
  Behavior:
    * Deduplicate IDs while preserving order.
    * Append only IDs to self.traits (store IDs ONLY).
    * If trait_catalog provided, for each trait_id:
        - apply grants_stats via increase_stat()
        - add any grants_abilities to self.abilities (set)
- Ensure add_class stores only the class ID in self.classes (no dicts).
- After refresh_derived(...), guarantee:
    self.stats["HP"]   = {"base": self.hp_max,   "current": self.hp}
    self.stats["Mana"] = {"base": self.mana_max, "current": self.mana}
  (Overwrite or create as needed to keep them synced.)

4) character_creation/models/npc_factory.py
- Replace any direct appends of class/trait dicts to hero.classes/hero.traits.
- Use hero.add_class(class_def) and hero.add_traits([trait_ids...], trait_catalog).
- Remove duplicate trait/class effect application logic; let Character handle it.

5) character_creation/ui/textual/state.py
- Only if it assumes hero.classes/hero.traits are dicts: update summarize_character() to treat them as IDs and look up labels from catalogs (use 'name' if present else the id).

TESTS TO UPDATE / ADD

6) tests/test_wizard_smoke.py
- Remove any monkeypatching that bypassed run_wizard argument handling.
- Build loaders_dict with the exact keys (stat_tmpl, slot_tmpl, appearance_fields, appearance_defaults, resources, class_catalog, trait_catalog).
- Monkeypatch input() to simulate:
    "TestHero", "1", "brave, lucky", ""  (name, first class, trait CSV, default save path)
- ASSERT:
    hero.name == "TestHero"
    "brave" in hero.traits                # IDs only
    hero.classes and isinstance(hero.classes[0], str)
    Trait effects applied:
      - If a selected trait grants a known stat (e.g., CHA/LCK/DEX), assert stat > initial.
      - If grants_abilities exists (e.g., "Lucky Step"), assert it in hero.abilities.

7) tests/test_npc_generation.py
- Align expectations with IDs in hero.traits and hero.classes.
- Remove assumptions that hero.traits contains dicts; treat them as IDs and use catalogs for labels if needed.
- Keep seeded determinism tests (if present) intact.

8) (Optional) tests/test_traits_apply.py
- New small test:
  - Create minimal Character from templates.
  - hero.add_traits(["brave"], trait_catalog)
  - Assert grants_stats/abilities applied, hero.traits == ["brave"].

ACCEPTANCE CRITERIA
- pre-commit run --all-files; pytest -q → all tests green.
- CLI wizard runs end-to-end (no internal monkeypatching) and Summary reflects trait effects.
- hero.classes / hero.traits are **lists of string IDs** everywhere (PC and NPC).
- After any refresh_derived, hero.stats has "HP"/"Mana" dicts with {base,current} matching hero.hp/mana.

CONSTRAINTS & STYLE
- Python 3.12; Black/Ruff; do not rename modules or public APIs beyond this spec.
- Minimal changes; prefer helper functions over refactors.
- Gracefully handle missing catalog entries (no KeyError).

PATCH PLAN (execution order)
1) scripts/create_character.py: fix loaders_dict keys → run_wizard.
2) wizard.run_wizard: after class selection, call hero.add_traits(selected_ids, trait_catalog).
3) character.add_traits: implement catalog-aware effects, dedupe, IDs only.
4) character.refresh_derived: ensure stats["HP"]/["Mana"] dicts synced to hp/mana.
5) npc_factory: use add_class/add_traits; remove manual dict appends and duplicate effect logic.
6) textual.state.summarize_character: ensure it looks up labels by ID if needed.
7) Update tests listed; add small trait-application test.
8) Run pre-commit + pytest; iterate until green.

FINAL COMMANDS (run in worldseed env)
pre-commit run --all-files; pytest -q
