### PR TITLE
updating all phase 5 items

### DIFF
--- a/character_creation_package/README.md
+++ b/character_creation_package/README.md
@@ -9,3 +9,36 @@ pip install -e .[dev]
 pre-commit install
 pytest -q
 ```
+
+Run the textual TUI:
+
+```bash
+python scripts/run_tui.py
+```
+
+Run the CLI wizard:
+
+```bash
+python scripts/create_character.py
+```
+
+Validate all game data quickly:
+
+```bash
+python scripts/validate_data.py
+```
+
+If validation passes you will see `OK`. A non-zero exit indicates validation failures.
+
+## Notes
+Character creation includes Race and Appearance steps in both the CLI (`worldseed-wizard`) and TUI (`worldseed-tui`).
+
+Trait limits are configurable via `character_creation/data/creation_limits.yaml`:
+
+```yaml
+limits:
+  traits_max: 2
+  edit_numeric_step: 0.5
+```
+
+Both the CLI and TUI enforce `traits_max` during selection.

--- a/character_creation_package/pyproject.toml
+++ b/character_creation_package/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 [project.scripts]
 worldseed-wizard = "scripts.create_character:main"
 worldseed-tui = "scripts.run_tui:main"
+worldseed-validate = "scripts.validate_data:main"
 worldseed-npc-demo = "scripts.generate_npcs:main"
 worldseed-xp-demo = "scripts.grant_xp:main"
 worldseed-regen-demo = "scripts.sim_regen:main"

--- a/character_creation_package/scripts/validate_data.py
+++ b/character_creation_package/scripts/validate_data.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from character_creation.loaders import (
+    stats_loader,
+    classes_loader,
+    traits_loader,
+    slots_loader,
+    items_loader,
+    appearance_loader,
+    races_loader,
+)
+from character_creation.services.validate_data import (
+    DataValidationError,
+    validate_stats,
+    validate_classes,
+    validate_traits,
+    validate_slots,
+    validate_items,
+    validate_races,
+    validate_appearance_fields,
+    validate_appearance_table,
+    validate_numeric_range,
+    validate_creation_limits,
+)
+
+
+def main() -> int:
+    root = Path(__file__).parents[1] / "character_creation" / "data"
+    try:
+        # Load core data
+        stats = stats_loader.load_stat_template(root / "stats" / "stats.yaml")
+        classes = classes_loader.load_class_catalog(root / "classes.yaml")
+        traits = traits_loader.load_trait_catalog(root / "traits.yaml")
+        slots = slots_loader.load_slot_template(root / "slots.yaml")
+        items = (
+            items_loader.load_item_catalog(root / "items.yaml")
+            if (root / "items.yaml").exists()
+            else {}
+        )
+        races = races_loader.load_race_catalog(root / "races.yaml")
+        appearance_fields = appearance_loader.load_appearance_fields(
+            root / "appearance" / "fields.yaml"
+        )
+        # defaults/resources are optional for validation and not required here
+        # One table and one range, if available
+        tables_dir = root / "appearance" / "tables"
+        ranges_dir = root / "appearance" / "ranges"
+        any_table = None
+        any_table_name = None
+        if tables_dir.exists():
+            for p in tables_dir.glob("*.yaml"):
+                any_table = appearance_loader.load_enum(p.name, base_dir=tables_dir)
+                any_table_name = p.name
+                break
+        any_range = None
+        any_range_name = None
+        if ranges_dir.exists():
+            for p in ranges_dir.glob("*.yaml"):
+                any_range = appearance_loader.load_range(p.name, base_dir=ranges_dir)
+                any_range_name = p.name
+                break
+        # Creation limits
+        limits_path = root / "creation_limits.yaml"
+        limits = {}
+        if limits_path.exists():
+            from character_creation.loaders.yaml_utils import load_yaml
+
+            limits = load_yaml(limits_path)
+
+        # Run validators
+        validate_stats(stats)
+        validate_classes(classes)
+        validate_traits(traits)
+        validate_slots(slots)
+        if items:
+            validate_items(items, slots)
+        validate_races(races)
+        validate_appearance_fields(appearance_fields)
+        if any_table is not None and any_table_name is not None:
+            validate_appearance_table(any_table, any_table_name)
+        if any_range is not None and any_range_name is not None:
+            validate_numeric_range(any_range, any_range_name)
+        if limits:
+            validate_creation_limits(limits)
+        print("OK")
+        return 0
+    except DataValidationError as e:
+        print(f"Validation failed: {e}")
+        return 1
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/character_creation_package/tests/test_summary_fields.py
+++ b/character_creation_package/tests/test_summary_fields.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import pytest
+
+from character_creation.loaders import (
+    stats_loader,
+    classes_loader,
+    traits_loader,
+    races_loader,
+    slots_loader,
+    appearance_loader,
+    resources_loader,
+)
+from character_creation.ui.cli import wizard as wiz
+
+
+DATA_ROOT = Path(__file__).parents[2] / "character_creation_package" / "character_creation" / "data"
+
+
+@pytest.fixture
+def loaders_dict():
+    return {
+        "stat_tmpl": stats_loader.load_stat_template(DATA_ROOT / "stats" / "stats.yaml"),
+        "class_catalog": classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml"),
+        "trait_catalog": traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml"),
+        "race_catalog": races_loader.load_race_catalog(DATA_ROOT / "races.yaml"),
+        "slot_tmpl": slots_loader.load_slot_template(DATA_ROOT / "slots.yaml"),
+        "appearance_fields": appearance_loader.load_appearance_fields(
+            DATA_ROOT / "appearance" / "fields.yaml"
+        ),
+        "appearance_defaults": appearance_loader.load_appearance_defaults(
+            DATA_ROOT / "appearance" / "defaults.yaml"
+        ),
+        "resources": resources_loader.load_resources(DATA_ROOT / "resources.yaml"),
+    }
+
+
+def test_cli_summary_contains_required_fields(monkeypatch, capsys, loaders_dict):
+    # Inputs through the wizard up to save prompt; _safe_input uses defaults for appearance
+    inputs = iter(
+        [
+            "SummaryHero",  # name
+            "1",  # race
+            "1",  # class
+            "brave, lucky",  # traits
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(wiz, "_safe_input", lambda prompt: "d")
+
+    hero = wiz.run_wizard(loaders_dict)
+    assert hero.name == "SummaryHero"
+
+    out = capsys.readouterr().out
+    # Required lines
+    assert "Name: SummaryHero" in out
+    assert "Race: " in out
+    assert "Class: " in out
+    assert "Traits: " in out and ("Brave" in out or "brave" in out)
+    assert "HP/Mana:" in out
+    # At least 3 appearance fields
+    assert "Appearance:" in out
+    # Check 3 keys present
+    for key in ["eye=", "hair=", "height=", "weight="]:
+        assert key in out

--- a/character_creation_package/tests/test_trait_limits.py
+++ b/character_creation_package/tests/test_trait_limits.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from character_creation.loaders import (
+    stats_loader,
+    classes_loader,
+    traits_loader,
+    races_loader,
+    slots_loader,
+    appearance_loader,
+    resources_loader,
+)
+
+
+DATA_ROOT = Path(__file__).parents[2] / "character_creation_package" / "character_creation" / "data"
+
+
+@pytest.fixture
+def loaders_dict():
+    return {
+        "stat_tmpl": stats_loader.load_stat_template(DATA_ROOT / "stats" / "stats.yaml"),
+        "class_catalog": classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml"),
+        "trait_catalog": traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml"),
+        "race_catalog": races_loader.load_race_catalog(DATA_ROOT / "races.yaml"),
+        "slot_tmpl": slots_loader.load_slot_template(DATA_ROOT / "slots.yaml"),
+        "appearance_fields": appearance_loader.load_appearance_fields(
+            DATA_ROOT / "appearance" / "fields.yaml"
+        ),
+        "appearance_defaults": appearance_loader.load_appearance_defaults(
+            DATA_ROOT / "appearance" / "defaults.yaml"
+        ),
+        "resources": resources_loader.load_resources(DATA_ROOT / "resources.yaml"),
+    }
+
+
+def test_cli_trait_limit_enforced(monkeypatch, capsys, loaders_dict):
+    # First attempt with 3 trait IDs should re-prompt; then provide valid <= max selection
+    from character_creation.ui.cli import wizard as wiz
+
+    inputs = iter(
+        [
+            "LimitHero",  # name
+            "1",  # race pick
+            "1",  # class pick
+            "brave, lucky, iron_will",  # too many traits
+            "brave, lucky",  # within limit
+        ]
+    )
+
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    # Make appearance prompts auto-default
+    monkeypatch.setattr(wiz, "_safe_input", lambda prompt: "d")
+
+    hero = wiz.run_wizard(loaders_dict)
+
+    # From creation_limits.yaml traits_max is 2 by default
+    assert len(getattr(hero, "traits", [])) == 2
+
+    out = capsys.readouterr().out
+    assert "Please select no more than" in out


### PR DESCRIPTION
Updates for cc_patch_5 including: 

ENVIRONMENT
Use the “worldseed” Python environment/interpreter for all indexing, analysis, and execution.

SYSTEM / ROLE
You are an expert Python game-systems engineer. Python 3.12, Black/Ruff, pytest. Make minimal, surgical edits. Do not rename/move files unless instructed.

PROJECT CONTEXT
After cc_patch_1..4 we have: races, appearance selection, validators, and save/load. This patch finishes the “v0.2 polished” experience:
- Enforce trait limits via YAML.
- Improve CLI summary (show race, class, trait names, appearance peek).
- Add a validator runner script for quick data checks.
- Tighten tests and README for the new flows.

GOALS
A) Enforce `traits_max` from `data/creation_limits.yaml` in **both** CLI and TUI.  
B) CLI Summary shows: name, race, class, traits (names), HP/Mana, 5 core stats, and 3–5 appearance fields.  
C) Add `scripts/validate_data.py` that runs all validators and returns non-zero on failure.  
D) Tests for trait limit enforcement + summary contents.  
E) README update to reflect Race/Appearance and validator usage.

FILES TO ADD / MODIFY

1) DATA LIMITS (ensure present): character_creation/data/creation_limits.yaml
- If file missing, create with:
---
limits:
  traits_max: 2
  edit_numeric_step: 0.5
---

2) CLI WIZARD: character_creation/ui/cli/wizard.py
- Import and read creation limits (use defaults if the file is missing): traits_max (int).
- In choose_traits(...):
  * Enforce max count == traits_max. If user enters more, show a gentle message and re-prompt.
  * Deduplicate and normalize spacing.
- In run_wizard(...): after hero is fully built (race, class, traits, appearance), print a compact summary before asking save path:
  Example:
    Name: {hero.name}
    Race: {race_label}
    Class: {class_label}
    Traits: {trait_names_csv}
    HP/Mana: {hp_current}/{hp_base} | {mana_current}/{mana_base}
    Stats: STR={...} DEX={...} INT={...} CHA={...} STA={...}
    Appearance: eye={...}, hair={...}, height={...}, weight={...}
- Keep language concise; don’t add new inputs besides the final save path prompt.

3) TUI APP: character_creation/ui/textual/app.py
- Trait selection panel must enforce `traits_max` from creation_limits.yaml:
  * If user selects more than max, prevent toggling the extra option or show a small notice.
- Keep behavior minimal; no heavy styling required.

4) VALIDATOR RUNNER: scripts/validate_data.py (new)
- Script loads all YAML data (stats, classes, traits, slots, items, races, appearance fields, one table, one range, creation_limits) and calls validators:
  validate_stats, validate_classes, validate_traits, validate_slots, validate_items,
  validate_races, validate_appearance_fields, validate_appearance_table (on any one table if exists),
  validate_numeric_range (on any one range if exists), validate_creation_limits.
- Print “OK” on success; on failure, print the error and exit(1).

5) TESTS
- tests/test_trait_limits.py (new):
  * Load creation_limits (or inject a local dict with traits_max=2).
  * Simulate choose_traits by calling the function directly or monkeypatching input sequence:
      - First attempt with 3 trait IDs → expect re-prompt and a valid <= max selection next.
      - Final result length == traits_max.
- tests/test_summary_fields.py (new):
  * Build a hero through the wizard helpers (or assemble via factory and apply set_race/add_class/add_traits/apply_appearance_selection).
  * Call the CLI summary helper if you split it out, or simulate run_wizard() up to the summary generation point.
  * Assert that the printed/returned summary includes name, race label, class label, at least one trait name, HP/Mana, and at least 3 appearance fields.

6) README.md
- Update Quick Start and “Console Commands”:
  * Add validator runner usage:
      ```bash
      python scripts/validate_data.py
      ```
  * Mention trait limit configuration in `data/creation_limits.yaml`.
  * Confirm Race and Appearance are interactive in both CLI (`worldseed-wizard`) and TUI (`worldseed-tui`).

INTEGRATION NOTES
- If creation_limits file absent, use safe defaults (traits_max=2).
- For CLI tests, you can monkeypatch `input` and capture stdout to verify summary lines.
- Reuse existing label lookup: use catalog ‘name’ if present else ID.

ACCEPTANCE CRITERIA
- `pre-commit run --all-files; pytest -q` passes.
- Choosing >traits_max traits in CLI/TUI is prevented or re-prompted.
- Validator runner exits 0 on valid data; non-zero on invalid.
- README reflects trait limits, race & appearance steps, and validator usage.

CONSTRAINTS & STYLE
- Python 3.12; Black/Ruff; minimal changes; fail gracefully on missing optional files.
- Keep public APIs stable. No breaking changes to model signatures beyond what’s already landed.

PATCH PLAN (execution order)
1) Ensure/create creation_limits.yaml (if missing).
2) Enforce trait max in CLI choose_traits; add compact Summary block.
3) Enforce trait max in TUI trait panel.
4) Add scripts/validate_data.py.
5) Add tests for trait limit and summary content.
6) README updates.
7) Run pre-commit + pytest; iterate until green.

FINAL COMMANDS (worldseed env)
pre-commit run --all-files; pytest -q
