### PR TITLE
updating all phase 6 items

### DIFF
--- a/character_creation_package/README.md
+++ b/character_creation_package/README.md
@@ -42,3 +42,40 @@ limits:
 ```
 
 Both the CLI and TUI enforce `traits_max` during selection.
+
+## Content Packs
+
+You can extend the base catalogs (classes, traits, races, items, and appearance tables) via Content Packs without changing any code.
+
+- Config file: `character_creation/data/content_packs.yaml`
+
+  Example:
+
+  ```yaml
+  enabled:
+    - starter_pack
+  merge:
+    on_conflict: "skip"  # one of: "skip" | "override" | "error"
+  ```
+
+- To add or enable a pack:
+  - Place the pack under `character_creation/data/content_packs/<pack_name>/`
+  - Reference it under `enabled:` in `content_packs.yaml`
+
+- Supported files inside a pack (all optional):
+  - `classes.yaml` (list or {classes: [...]})
+  - `traits.yaml` ({traits: {...}} or direct mapping)
+  - `races.yaml` (list or {races: [...]})
+  - `items.yaml` (list or {items: [...]})
+  - `appearance/tables/*.yaml` (list or {values: [...]})
+
+- Merge policies:
+  - **skip**: keep base entry when ids collide
+  - **override**: replace base entry with pack's
+  - **error**: raise on id collision
+
+- Validation and tooling:
+  - Validate data: `python scripts/validate_data.py`
+  - List enabled packs and counts: `python scripts/list_content_packs.py`
+
+The CLI and TUI automatically load and merge enabled packs at startup; newly added classes and races will appear in selection lists, and appearance enums are unioned with pack-provided values.

--- a/character_creation_package/character_creation/data/content_packs.yaml
+++ b/character_creation_package/character_creation/data/content_packs.yaml
@@ -1,0 +1,4 @@
+enabled:
+  - starter_pack
+merge:
+  on_conflict: "skip"  # one of: "skip" | "override" | "error"

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/eye_color.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/eye_color.yaml
@@ -1,0 +1,6 @@
+values:
+  - amber
+  - hazel
+  - violet
+  - silver
+  - gold

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/hair_style.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/hair_style.yaml
@@ -1,0 +1,8 @@
+values:
+  - buzzcut
+  - bob
+  - shoulder_length
+  - braided
+  - topknot
+  - mohawk
+  - bald

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/skin_tone.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/appearance/tables/skin_tone.yaml
@@ -1,0 +1,8 @@
+values:
+  - alabaster
+  - porcelain
+  - fair
+  - olive
+  - bronze
+  - umber
+  - ebony

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/classes.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/classes.yaml
@@ -1,0 +1,49 @@
+classes:
+  - id: duelist
+    name: Duelist
+    grants_stats: { DEX: 1.0, STR: 0.5 }
+    grants_abilities: ["Riposte"]
+  - id: battlemage
+    name: Battlemage
+    grants_stats: { INT: 1.0, STR: 0.5 }
+    grants_abilities: ["Arcane Slash"]
+  - id: ranger
+    name: Ranger
+    grants_stats: { DEX: 1.0, STA: 0.5 }
+    grants_abilities: ["Multi Shot"]
+  - id: bard
+    name: Bard
+    grants_stats: { CHA: 1.0 }
+    grants_abilities: ["Inspiring Tune"]
+  - id: paladin
+    name: Paladin
+    grants_stats: { STR: 0.8, WIS: 0.8 }
+    grants_abilities: ["Lay on Hands"]
+  - id: monk
+    name: Monk
+    grants_stats: { DEX: 0.8, WIS: 0.8 }
+    grants_abilities: ["Flurry"]
+  - id: necromancer
+    name: Necromancer
+    grants_stats: { INT: 1.2 }
+    grants_abilities: ["Raise Skeleton"]
+  - id: druid
+    name: Druid
+    grants_stats: { WIS: 1.0 }
+    grants_abilities: ["Wild Shape"]
+  - id: barbarian
+    name: Barbarian
+    grants_stats: { STR: 1.2, STA: 0.6 }
+    grants_abilities: ["Rage"]
+  - id: assassin
+    name: Assassin
+    grants_stats: { DEX: 1.2 }
+    grants_abilities: ["Shadowstep"]
+  - id: chronomancer
+    name: Chronomancer
+    grants_stats: { INT: 1.1, WIS: 0.4 }
+    grants_abilities: ["Time Warp"]
+  - id: sentinel
+    name: Sentinel
+    grants_stats: { STA: 1.2 }
+    grants_abilities: ["Guard"]

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/items.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/items.yaml
@@ -1,0 +1,130 @@
+items:
+  - id: spear_oak
+    name: Oak Spear
+    slot: [hand_main, hand_off]
+    type: weapon
+    tags: [melee, polearm]
+    mods:
+      stats: { strength: 1.0, agility: 0.5 }
+      abilities: ["pierce"]
+    value: 35
+    weight: 3.0
+
+  - id: staff_ash
+    name: Ash Staff
+    slot: [hand_main]
+    type: weapon
+    tags: [magic, wood]
+    mods:
+      stats: { intelligence: 1.0 }
+      mana: 5.0
+      abilities: ["channel"]
+    value: 60
+    weight: 2.5
+
+  - id: dagger_obsidian
+    name: Obsidian Dagger
+    slot: [hand_main, hand_off]
+    type: weapon
+    tags: [melee, blade]
+    mods:
+      stats: { dexterity: 1.0 }
+      abilities: ["bleed"]
+    value: 45
+    weight: 0.8
+
+  - id: helm_bronze
+    name: Bronze Helm
+    slot: armor_head
+    type: armor
+    tags: [medium, metal]
+    mods:
+      stats: { defense: 1.5 }
+      hp: 2
+    value: 55
+    weight: 2.2
+
+  - id: cuirass_bronze
+    name: Bronze Cuirass
+    slot: armor_top
+    type: armor
+    tags: [medium, metal]
+    mods:
+      stats: { defense: 3.5 }
+      hp: 6
+    value: 140
+    weight: 9.5
+
+  - id: boots_ranger
+    name: Ranger Boots
+    slot: cloth_feet
+    type: clothing
+    tags: [light, leather]
+    mods:
+      stats: { agility: 1.0 }
+    value: 30
+    weight: 0.9
+
+  - id: cloak_shadow
+    name: Shadow Cloak
+    slot: clothing
+    type: clothing
+    tags: [cloth, stealth]
+    mods:
+      stats: { agility: 0.5 }
+      abilities: ["vanish"]
+    value: 120
+    weight: 1.0
+
+  - id: ring_sage
+    name: Sage's Ring
+    slot: accessory
+    type: accessory
+    tags: [jewelry, magic]
+    mods:
+      mana: 10
+      abilities: ["wisdom_insight"]
+    value: 180
+    weight: 0.05
+
+  - id: amulet_guardian
+    name: Guardian Amulet
+    slot: accessory
+    type: accessory
+    tags: [jewelry, protection]
+    mods:
+      stats: { defense: 1.0 }
+      hp: 5
+    value: 160
+    weight: 0.1
+
+  - id: gloves_thief
+    name: Thief's Gloves
+    slot: cloth_wrists
+    type: clothing
+    tags: [light, leather]
+    mods:
+      stats: { agility: 0.5 }
+    value: 25
+    weight: 0.3
+
+  - id: belt_adventurer
+    name: Adventurer's Belt
+    slot: cloth_ankles
+    type: clothing
+    tags: [cloth]
+    mods:
+      stats: { defense: 0.3 }
+    value: 15
+    weight: 0.4
+
+  - id: robe_mystic
+    name: Mystic Robe
+    slot: cloth_torso
+    type: clothing
+    tags: [cloth, magic]
+    mods:
+      stats: { intelligence: 0.8 }
+      mana: 8
+    value: 200
+    weight: 1.8

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/races.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/races.yaml
@@ -1,0 +1,29 @@
+races:
+  - id: gnome
+    name: Gnome
+    grants_stats: { INT: 0.2, DEX: 0.1 }
+    grants_abilities: ["tinker"]
+  - id: tiefling
+    name: Tiefling
+    grants_stats: { CHA: 0.2, INT: 0.1 }
+    grants_abilities: ["infernal_legacy"]
+  - id: aasimar
+    name: Aasimar
+    grants_stats: { WIS: 0.2, CHA: 0.1 }
+    grants_abilities: ["heavenly_resilience"]
+  - id: lizardfolk
+    name: Lizardfolk
+    grants_stats: { STA: 0.3 }
+    grants_abilities: ["amphibious"]
+  - id: goblin
+    name: Goblin
+    grants_stats: { DEX: 0.2 }
+    grants_abilities: ["nimble_escape"]
+  - id: kitsune
+    name: Kitsune
+    grants_stats: { CHA: 0.2, DEX: 0.1 }
+    grants_abilities: ["foxfire"]
+  - id: automaton
+    name: Automaton
+    grants_stats: { STA: 0.3, INT: 0.1 }
+    grants_abilities: ["mechanical_precision"]

--- a/character_creation_package/character_creation/data/content_packs/starter_pack/traits.yaml
+++ b/character_creation_package/character_creation/data/content_packs/starter_pack/traits.yaml
@@ -1,0 +1,42 @@
+traits:
+  iron_skin:
+    name: Iron Skin
+    desc: Toughened hide resists damage.
+    grants_stats: { DEF: 1.0 }
+  fleet_footed:
+    name: Fleet-Footed
+    desc: Moves swiftly and silently.
+    grants_stats: { DEX: 0.5 }
+  arcane_attunement:
+    name: Arcane Attunement
+    desc: Natural connection to magic.
+    grants_abilities: ["Arcane Surge"]
+  beast_friend:
+    name: Beast Friend
+    desc: Calms animals with ease.
+  stoic:
+    name: Stoic
+    desc: Resists pain and fear.
+  keen_mind:
+    name: Keen Mind
+    desc: Remembers everything seen.
+    grants_stats: { INT: 0.5 }
+  silver_blood:
+    name: Silver Blood
+    desc: Wards off curses.
+  stoneborn:
+    name: Stoneborn
+    desc: Rooted and resilient.
+    grants_stats: { STA: 0.5 }
+  fiery_spirit:
+    name: Fiery Spirit
+    desc: Passion fuels actions.
+  shadow_touched:
+    name: Shadow-Touched
+    desc: Blends into darkness.
+  blessed:
+    name: Blessed
+    desc: Fortune favors you.
+  tinkerer:
+    name: Tinkerer
+    desc: Expert with gadgets.

--- a/character_creation_package/character_creation/loaders/content_packs_loader.py
+++ b/character_creation_package/character_creation/loaders/content_packs_loader.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+def load_packs_config(path: str | Path) -> Dict[str, Any]:
+    """
+    Load content packs configuration from YAML. If missing or invalid, return defaults.
+
+    Expected schema:
+    {
+      enabled: [pack_name, ...],
+      merge: { on_conflict: "skip" | "override" | "error" }
+    }
+    """
+    path = Path(path)
+    try:
+        if not path.exists():
+            return {"enabled": [], "merge": {"on_conflict": "skip"}}
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        enabled = data.get("enabled") or []
+        if not isinstance(enabled, list):
+            enabled = []
+        merge = data.get("merge") or {}
+        if not isinstance(merge, dict):
+            merge = {}
+        on_conflict = merge.get("on_conflict") or "skip"
+        if on_conflict not in {"skip", "override", "error"}:
+            on_conflict = "skip"
+        return {"enabled": list(enabled), "merge": {"on_conflict": on_conflict}}
+    except Exception:
+        return {"enabled": [], "merge": {"on_conflict": "skip"}}
+
+
+def _read_yaml_optional(path: Path) -> Any:
+    try:
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+def load_pack_dir(pack_dir: Path) -> Dict[str, Any]:
+    """
+    Load a single content pack directory structure into a catalog-like dict.
+    Recognized files (all optional):
+      classes.yaml -> {"classes": [...]}
+      traits.yaml -> {"traits": {...}}
+      races.yaml -> {"races": [...]}
+      items.yaml -> {"items": [...] or {items: [...]}}
+      appearance/tables/*.yaml -> {"appearance_tables": {name: [values...]}}
+    """
+    result: Dict[str, Any] = {}
+    # Classes
+    classes_path = pack_dir / "classes.yaml"
+    data = _read_yaml_optional(classes_path)
+    if isinstance(data, dict) and isinstance(data.get("classes"), list):
+        result["classes"] = list(data["classes"])  # shallow copy
+    elif isinstance(data, list):
+        result["classes"] = list(data)
+
+    # Traits
+    traits_path = pack_dir / "traits.yaml"
+    data = _read_yaml_optional(traits_path)
+    if isinstance(data, dict):
+        traits = data.get("traits", data)
+        if isinstance(traits, dict):
+            result["traits"] = dict(traits)
+
+    # Races
+    races_path = pack_dir / "races.yaml"
+    data = _read_yaml_optional(races_path)
+    if isinstance(data, dict) and isinstance(data.get("races"), list):
+        result["races"] = list(data["races"])  # shallow copy
+    elif isinstance(data, list):
+        result["races"] = list(data)
+
+    # Items
+    items_path = pack_dir / "items.yaml"
+    data = _read_yaml_optional(items_path)
+    if isinstance(data, dict):
+        if isinstance(data.get("items"), list):
+            result["items"] = list(data.get("items"))
+        else:
+            # Some repos use dict keyed by id; normalize to list
+            # Accept either a list at top-level or dict of id->item
+            items_block = data
+            if isinstance(items_block, dict):
+                # If values look like items (dicts with id), flatten
+                vals = list(items_block.values())
+                if vals and isinstance(vals[0], dict) and ("id" in vals[0] or "name" in vals[0]):
+                    result["items"] = vals
+    elif isinstance(data, list):
+        result["items"] = list(data)
+
+    # Appearance tables
+    app_tables_dir = pack_dir / "appearance" / "tables"
+    if app_tables_dir.exists() and app_tables_dir.is_dir():
+        tables: Dict[str, List[Any]] = {}
+        for child in sorted(app_tables_dir.glob("*.yaml")):
+            loaded = _read_yaml_optional(child)
+            values: List[Any] | None = None
+            if isinstance(loaded, dict) and "values" in loaded:
+                maybe_values = loaded.get("values")
+                if isinstance(maybe_values, list):
+                    values = maybe_values
+            elif isinstance(loaded, list):
+                values = loaded
+            if values is not None:
+                tables[child.stem] = list(values)
+        if tables:
+            result["appearance_tables"] = tables
+
+    return result
+
+
+def _merge_indexed_lists(
+    base: List[Dict[str, Any]] | None,
+    incoming: List[Dict[str, Any]] | None,
+    on_conflict: str,
+) -> List[Dict[str, Any]]:
+    base = list(base or [])
+    if not incoming:
+        return base
+    # Build index for base by id
+    index: Dict[str, int] = {}
+    for i, entry in enumerate(base):
+        if isinstance(entry, dict) and "id" in entry:
+            index[str(entry["id"])] = i
+    for entry in incoming:
+        if not isinstance(entry, dict) or "id" not in entry:
+            continue
+        eid = str(entry["id"])
+        if eid in index:
+            if on_conflict == "skip":
+                continue
+            if on_conflict == "error":
+                raise ValueError(f"Duplicate id '{eid}' during merge")
+            # override
+            base[index[eid]] = entry
+        else:
+            base.append(entry)
+            index[eid] = len(base) - 1
+    return base
+
+
+def _merge_traits(
+    base: Dict[str, Any] | None, incoming: Dict[str, Any] | None, on_conflict: str
+) -> Dict[str, Any]:
+    base = dict(base or {})
+    incoming = dict(incoming or {})
+    for tid, meta in incoming.items():
+        if tid in base:
+            if on_conflict == "skip":
+                continue
+            if on_conflict == "error":
+                raise ValueError(f"Duplicate trait id '{tid}' during merge")
+        base[tid] = meta
+    return base
+
+
+def _union_preserve_order(base_vals: List[Any] | None, new_vals: List[Any] | None) -> List[Any]:
+    result: List[Any] = []
+    seen: set[Any] = set()
+    for arr in (base_vals or [], new_vals or []):
+        for v in arr:
+            key = v
+            if key not in seen:
+                seen.add(key)
+                result.append(v)
+    return result
+
+
+def merge_catalogs(
+    base: Dict[str, Any], pack: Dict[str, Any], on_conflict: str = "skip"
+) -> Dict[str, Any]:
+    """
+    Merge two catalogs following rules described in the spec.
+    Return a new merged dict with any present keys.
+    """
+    result: Dict[str, Any] = {}
+
+    # classes/races/items are lists of dicts with id
+    for key in ("classes", "races", "items"):
+        if key in base or key in pack:
+            result[key] = _merge_indexed_lists(base.get(key), pack.get(key), on_conflict)
+
+    # traits is a mapping of id -> meta; may be nested under 'traits'
+    base_traits = base.get("traits")
+    pack_traits = pack.get("traits")
+    if base_traits is not None or pack_traits is not None:
+        result["traits"] = _merge_traits(base_traits or {}, pack_traits or {}, on_conflict)
+
+    # appearance_tables: dict name -> list of scalars; union lists
+    base_tables = base.get("appearance_tables") or {}
+    pack_tables = pack.get("appearance_tables") or {}
+    if base_tables or pack_tables:
+        merged_tables: Dict[str, List[Any]] = {}
+        for tname in sorted(set(base_tables.keys()) | set(pack_tables.keys())):
+            merged_tables[tname] = _union_preserve_order(
+                base_tables.get(tname), pack_tables.get(tname)
+            )
+        result["appearance_tables"] = merged_tables
+
+    return result
+
+
+def load_and_merge_enabled_packs(base_root: Path, packs_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    For each pack in cfg["enabled"], load its directory under base_root/content_packs/<name>,
+    and merge into an accumulator according to cfg["merge"]["on_conflict"].
+    Returns a single catalog-like dict with any of the supported keys present.
+    """
+    enabled: List[str] = list((packs_cfg or {}).get("enabled") or [])
+    on_conflict = ((packs_cfg or {}).get("merge") or {}).get("on_conflict", "skip")
+    if on_conflict not in {"skip", "override", "error"}:
+        on_conflict = "skip"
+
+    acc: Dict[str, Any] = {}
+    content_dir = base_root / "content_packs"
+    for name in enabled:
+        pack_dir = content_dir / name
+        pack_data = load_pack_dir(pack_dir)
+        # Merge pack_data into acc using merge_catalogs, with acc as base and pack as overlay
+        acc = merge_catalogs(acc, pack_data, on_conflict)
+    return acc

--- a/character_creation_package/character_creation/ui/cli/wizard.py
+++ b/character_creation_package/character_creation/ui/cli/wizard.py
@@ -98,6 +98,11 @@ def choose_appearance(
     base_dir = Path(data_dir)
     spec = appearance_fields.get("fields", appearance_fields)
     selections: Dict[str, Any] = {}
+    # Optional extra appearance tables from content packs
+    try:
+        extra_tables = appearance_fields.get("_extra_appearance_tables")
+    except Exception:
+        extra_tables = None
 
     for field_id, meta in spec.items():
         ftype = meta.get("type", "any")
@@ -111,7 +116,7 @@ def choose_appearance(
 
         while True:
             if ftype == "enum":
-                values = get_enum_values(field_id, appearance_fields, base_dir)
+                values = get_enum_values(field_id, appearance_fields, base_dir, extra_tables)
                 if not values:
                     print(f"[warn] No table for enum field '{field_id}', using default")
                     selections[field_id] = default_val

--- a/character_creation_package/scripts/list_content_packs.py
+++ b/character_creation_package/scripts/list_content_packs.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from character_creation.loaders.content_packs_loader import (
+    load_packs_config,
+    load_and_merge_enabled_packs,
+)
+
+
+def main() -> None:
+    root = Path(__file__).parents[1] / "character_creation" / "data"
+    cfg = load_packs_config(root / "content_packs.yaml")
+    merged = load_and_merge_enabled_packs(root, cfg)
+
+    enabled = cfg.get("enabled", [])
+    policy = (cfg.get("merge") or {}).get("on_conflict", "skip")
+    print(f"Enabled packs: {', '.join(enabled) if enabled else '(none)'}")
+    print(f"Merge policy: {policy}")
+
+    def count(key: str) -> int:
+        v = merged.get(key)
+        if key in {"classes", "races", "items"}:
+            return len(v or [])
+        if key == "traits":
+            return len((v or {}).keys())
+        return 0
+
+    print("Counts after merging:")
+    print(f"  classes: {count('classes')}")
+    print(f"  traits:  {count('traits')}")
+    print(f"  races:   {count('races')}")
+    print(f"  items:   {count('items')}")
+
+    tables = merged.get("appearance_tables") or {}
+    if tables:
+        print("Appearance tables extended:")
+        for name, values in tables.items():
+            print(f"  {name}: +{len(values)} values")
+
+
+if __name__ == "__main__":
+    main()

--- a/character_creation_package/tests/test_content_packs_in_wizard.py
+++ b/character_creation_package/tests/test_content_packs_in_wizard.py
@@ -1,0 +1,123 @@
+import builtins
+from pathlib import Path
+
+from character_creation.loaders import (
+    stats_loader,
+    slots_loader,
+    appearance_loader,
+    resources_loader,
+    classes_loader,
+    traits_loader,
+    races_loader,
+)
+from character_creation.loaders.content_packs_loader import (
+    load_packs_config,
+    load_and_merge_enabled_packs,
+    merge_catalogs,
+)
+from character_creation.ui.cli.wizard import run_wizard
+
+
+DATA_ROOT = Path(__file__).parents[2] / "character_creation_package" / "character_creation" / "data"
+
+
+def test_wizard_can_select_pack_race_and_class(monkeypatch, tmp_path):
+    # Base
+    stat_tmpl = stats_loader.load_stat_template(DATA_ROOT / "stats" / "stats.yaml")
+    slot_tmpl = slots_loader.load_slot_template(DATA_ROOT / "slots.yaml")
+    appearance_fields = appearance_loader.load_appearance_fields(
+        DATA_ROOT / "appearance" / "fields.yaml"
+    )
+    appearance_defaults = appearance_loader.load_appearance_defaults(
+        DATA_ROOT / "appearance" / "defaults.yaml"
+    )
+    resources = resources_loader.load_resources(DATA_ROOT / "resources.yaml")
+    base_classes = classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml")
+    base_traits = traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml")
+    base_races = races_loader.load_race_catalog(DATA_ROOT / "races.yaml")
+
+    # Merge packs
+    packs_cfg = load_packs_config(DATA_ROOT / "content_packs.yaml")
+    merged_overlay = load_and_merge_enabled_packs(DATA_ROOT, packs_cfg)
+    policy = packs_cfg.get("merge", {}).get("on_conflict", "skip")
+    base = {
+        "classes": base_classes.get("classes", base_classes),
+        "traits": base_traits.get("traits", base_traits),
+        "races": base_races.get("races", base_races),
+    }
+    merged_all = merge_catalogs(base, merged_overlay, on_conflict=policy)
+    class_catalog = {"classes": merged_all.get("classes", [])}
+    trait_catalog = {"traits": merged_all.get("traits", {})}
+    race_catalog = {"races": merged_all.get("races", [])}
+
+    # Find indices of a pack-provided entry by name or id
+    pack_class_id = None
+    for cls in class_catalog["classes"]:
+        if cls.get("id") in {
+            "duelist",
+            "battlemage",
+            "ranger",
+            "bard",
+            "paladin",
+            "monk",
+            "necromancer",
+            "druid",
+            "barbarian",
+            "assassin",
+            "chronomancer",
+            "sentinel",
+        }:
+            pack_class_id = cls["id"]
+            break
+    assert pack_class_id is not None, "Expected a pack-provided class id"
+
+    pack_race_id = None
+    for r in race_catalog["races"]:
+        if r.get("id") in {
+            "gnome",
+            "tiefling",
+            "aasimar",
+            "lizardfolk",
+            "goblin",
+            "kitsune",
+            "automaton",
+        }:
+            pack_race_id = r["id"]
+            break
+    assert pack_race_id is not None, "Expected a pack-provided race id"
+
+    # Map to visible indices in CLI lists (1-based)
+    class_index_1based = None
+    for idx, cls in enumerate(class_catalog["classes"], 1):
+        if cls.get("id") == pack_class_id and not cls.get("prereq"):
+            class_index_1based = idx
+            break
+    assert class_index_1based is not None
+
+    race_index_1based = None
+    for idx, r in enumerate(race_catalog["races"], 1):
+        if r.get("id") == pack_race_id:
+            race_index_1based = idx
+            break
+    assert race_index_1based is not None
+
+    # Inputs: name, pick race index, pick class index, provide a valid trait id (e.g., 'brave')
+    inputs = iter(["PackHero", str(race_index_1based), str(class_index_1based), "brave"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+
+    hero = run_wizard(
+        {
+            "stat_tmpl": stat_tmpl,
+            "slot_tmpl": slot_tmpl,
+            "appearance_fields": appearance_fields,
+            "appearance_defaults": appearance_defaults,
+            "resources": resources,
+            "class_catalog": class_catalog,
+            "trait_catalog": trait_catalog,
+            "race_catalog": race_catalog,
+        }
+    )
+
+    assert hero.name == "PackHero"
+    assert hero.race == pack_race_id
+    assert hero.classes and pack_class_id in hero.classes

--- a/character_creation_package/tests/test_content_packs_merge.py
+++ b/character_creation_package/tests/test_content_packs_merge.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from character_creation.loaders import (
+    classes_loader,
+    traits_loader,
+    races_loader,
+)
+from character_creation.loaders.content_packs_loader import (
+    load_packs_config,
+    load_and_merge_enabled_packs,
+    merge_catalogs,
+)
+from character_creation.services.validate_data import validate_merged_catalogs
+
+
+DATA_ROOT = Path(__file__).parents[2] / "character_creation_package" / "character_creation" / "data"
+
+
+def test_content_packs_merge_and_validate():
+    # Load base catalogs
+    base_classes = classes_loader.load_class_catalog(DATA_ROOT / "classes.yaml")
+    base_traits = traits_loader.load_trait_catalog(DATA_ROOT / "traits.yaml")
+    base_races = races_loader.load_race_catalog(DATA_ROOT / "races.yaml")
+
+    # Load packs config and merged overlay
+    packs_cfg = load_packs_config(DATA_ROOT / "content_packs.yaml")
+    merged_overlay = load_and_merge_enabled_packs(DATA_ROOT, packs_cfg)
+
+    # Merge overlay into base copies
+    policy = packs_cfg.get("merge", {}).get("on_conflict", "skip")
+    base = {
+        "classes": base_classes.get("classes", base_classes),
+        "traits": base_traits.get("traits", base_traits),
+        "races": base_races.get("races", base_races),
+    }
+    merged_all = merge_catalogs(base, merged_overlay, on_conflict=policy)
+
+    # Assertions: lengths should grow or remain same
+    assert len(merged_all.get("classes", [])) >= len(base.get("classes", []))
+    assert len(merged_all.get("races", [])) >= len(base.get("races", []))
+    assert len((merged_all.get("traits", {}) or {}).keys()) >= len(
+        (base.get("traits", {}) or {}).keys()
+    )
+
+    # Appearance tables union sanity: if present, ensure at least one table includes all values
+    if "appearance_tables" in merged_overlay:
+        tables = merged_overlay["appearance_tables"]
+        assert isinstance(tables, dict) and tables
+        # Pick any one
+        tname, pack_vals = next(iter(tables.items()))
+        merged_vals = merged_all.get("appearance_tables", {}).get(tname, [])
+        for v in pack_vals:
+            assert v in merged_vals
+
+    # Validate merged
+    validate_merged_catalogs(merged_all)


### PR DESCRIPTION
Update for cc_patch_6 which includes:

ENVIRONMENT
Use the “worldseed” Python environment/interpreter for all indexing, analysis, and execution.

SYSTEM / ROLE
You are an expert Python game-systems engineer. Python 3.12, Black/Ruff, pytest. Minimal, surgical edits. Don’t rename/move files unless instructed.

GOAL
Introduce **Content Packs** that extend base YAML with more classes, traits, races, items, and appearance tables — loaded at runtime via config, merged with base catalogs, validated, and used by CLI/TUI without code changes.

SCOPE
- Data layout under character_creation/data/content_packs/
- Config `content_packs.yaml` to enable packs & set merge policy
- Loader/merger utilities
- Wiring into CLI & TUI loaders
- Tests for merging & validation
- Docs & a tiny tool to inspect packs

──────────────────────────────────────────────────────────────────────────────

ADD DATA CONFIG
1) character_creation/data/content_packs.yaml
---
enabled:
  - starter_pack
merge:
  on_conflict: "skip"    # one of: "skip" | "override" | "error"
---

2) character_creation/data/content_packs/starter_pack/ (new directory)
Create these files with reasonable, self-consistent content that fits existing slot/categories and stat keys:
- classes.yaml  (≥ 12 classes; include names and grants_*)
- traits.yaml   (≥ 12 traits; id-> {name, desc, grants_stats|grants_abilities optional})
- races.yaml    (6–8 races with id, name, grants_*)
- items.yaml    (≥ 12 items mixing weapons/armor/clothing/accessory; slots must align with base slot ids OR categories already supported; include some mods.stats, hp/mana, abilities)
- appearance/tables/*.yaml (add 2–3 new/expanded tables, e.g., hair_style.yaml, skin_tone.yaml, eye_color.yaml; lists of strings)

Make sure IDs don’t collide with existing base IDs where possible. If some collide, default policy “skip” will ignore pack duplicates.

──────────────────────────────────────────────────────────────────────────────

ADD LOADER & MERGE UTILITIES
3) character_creation/loaders/content_packs_loader.py
Implement:
- load_packs_config(path: str|Path) -> dict
- load_pack_dir(pack_dir: Path) -> dict
  Returns a dict with possible keys: {"classes": [...], "traits": {..}, "races": [...], "items": [...], "appearance_tables": {table_name: [values,...], ...}}
  Read known filenames if present; ignore missing files.
- merge_catalogs(base: dict, pack: dict, on_conflict: str = "skip") -> dict
  Rules:
    * classes/races/items (LISTS, keyed by "id"): merge by ID
        - skip: keep base when id collides
        - override: replace base entry with pack's
        - error: raise ValueError on collision
    * traits (DICT keyed by id): same policy per key
    * appearance_tables (DICT of list values): union lists by scalar equality, preserve order (base first, then new unique)
  Return a new merged dict containing any of: {"classes": [...], "traits": {...}, "races": [...], "items": [...], "appearance_tables": {...}}

- load_and_merge_enabled_packs(base_root: Path, packs_cfg: dict) -> dict
  For each pack name in cfg["enabled"] (in order), load pack_dir = base_root/"content_packs"/packname, load and merge with running merged dict using policy cfg["merge"]["on_conflict"].

Notes:
- Use yaml.safe_load
- Be tolerant to missing optional files

──────────────────────────────────────────────────────────────────────────────

WIRE INTO LOADERS (CLI & TUI)
4) scripts/create_character.py
After loading base catalogs (stats, slots, appearance_fields/defaults, resources, classes, traits, items, races):
- Load packs_cfg from data/content_packs.yaml (if present)
- merged = content_packs_loader.load_and_merge_enabled_packs(data_root, packs_cfg)
- For each key present in merged, merge with the base catalog the same way (reuse merge_catalogs or just assign merged overlay):
  * classes: extend/override base class_catalog["classes"]
  * traits: update base trait_catalog["traits"]
  * races: extend/override base race_catalog["races"]
  * items: extend/override item catalog
  * appearance_tables: when wizard/TUI fetch enum table values, prefer union of base table + pack-provided values
- Ensure the dict passed to wizard.run_wizard uses the **same keys** as established in cc_patch_1/2/3 plus race_catalog; pack-merged catalogs should be passed.

5) character_creation/ui/textual/app.py
At app startup when loading YAML:
- Load packs_cfg and merged content once.
- Apply merged content to in-memory catalogs exactly as in the CLI.
- For appearance enums, when fetching table values, include pack-expanded values (union).

(Do not deeply refactor; keep changes minimal. If appearance enums use a helper, hook the merged tables into that path.)

──────────────────────────────────────────────────────────────────────────────

VALIDATION INTEGRATION
6) character_creation/services/validate_data.py
Add helper:
- validate_no_duplicate_ids(list_of_dicts: list, kind: str) -> None  (raise DataValidationError if duplicate id)
Add pack-aware validator:
- validate_merged_catalogs(merged: dict) -> None
  * If "classes" in merged: validate_no_duplicate_ids(merged["classes"], "class")
  * If "races" in merged: validate_no_duplicate_ids(merged["races"], "race")
  * If "items" in merged: validate_no_duplicate_ids(merged["items"], "item")
  * If "traits" in merged: ensure dict keys unique (inherent); simple pass
  * If "appearance_tables": ensure values are lists of scalars

Optionally call existing validators over the merged catalogs if feasible.

──────────────────────────────────────────────────────────────────────────────

TESTS
7) tests/test_content_packs_merge.py (new)
- Load base data (classes/traits/races/items; appearance fields).
- Load packs_cfg and merged = load_and_merge_enabled_packs(...).
- Merge into copies of base catalogs and assert:
  * len(merged classes) >= len(base classes)  (if pack provides new)
  * len(merged traits) >= len(base traits)
  * len(merged races) >= len(base races)
  * len(merged items) >= len(base items)
  * If appearance_tables present: confirm union contains all base + pack values for at least one table
- Run validate_merged_catalogs(merged) without errors.

8) tests/test_content_packs_in_wizard.py (new)
- Build a loaders_dict like the CLI would (after merging packs).
- Monkeypatch input to select a **pack-provided** race and class by visible index (ensure indexes include new entries; if uncertain, search the list by id or name to pick the index).
- Run run_wizard and assert the selected pack-provided race/class were applied (ids in hero.race/hero.classes[0]).

──────────────────────────────────────────────────────────────────────────────

OPTIONAL TOOLING
9) scripts/list_content_packs.py (new)
- Print enabled packs, merge policy, and counts per type after merging (classes/traits/races/items), and list any appearance tables extended.

──────────────────────────────────────────────────────────────────────────────

DOCS
10) README.md
Add a **Content Packs** section:
- Explain `character_creation/data/content_packs.yaml` config
- Add/enable a pack by placing a folder under `data/content_packs/<pack_name>` and adding it to `enabled:`
- Explain merge policies: **skip** (default), **override**, **error**
- Show how to run validator: `python scripts/validate_data.py`
- Show how to list packs: `python scripts/list_content_packs.py`

──────────────────────────────────────────────────────────────────────────────

ACCEPTANCE CRITERIA
- `pre-commit run --all-files; pytest -q` passes.
- With starter_pack enabled, merged catalogs expose more classes/traits/races/items than base.
- Wizard & TUI use merged catalogs (you can pick starter_pack races/classes).
- Validators pass on merged content (no duplicate ids unless policy=override).
- README documents content packs clearly.

CONSTRAINTS & STYLE
- Python 3.12; Black/Ruff; minimal edits; fail gracefully if config/files missing.
- Do not break existing public APIs; only add new loader utilities.

PATCH PLAN
1) Add content_packs.yaml and starter_pack data files.
2) Implement content_packs_loader with load/merge functions.
3) Wire merging into CLI and TUI loaders.
4) Extend validators with merged catalog checks.
5) Add tests for merge and wizard consumption.
6) Add list_content_packs.py and README docs.
7) Run pre-commit + pytest; iterate until green.

FINAL COMMANDS (worldseed env)
pre-commit run --all-files; pytest -q
