### PR TITLE
updating for cc_patch_7

### DIFF
--- a/character_creation_package/Makefile
+++ b/character_creation_package/Makefile
@@ -35,3 +35,6 @@ effects-demo:
 
 save-demo:
 	python -m scripts.demo_save_load
+
+dev-watch:
+	python scripts/dev_watch.py

--- a/character_creation_package/README.md
+++ b/character_creation_package/README.md
@@ -79,3 +79,8 @@ You can extend the base catalogs (classes, traits, races, items, and appearance 
   - List enabled packs and counts: `python scripts/list_content_packs.py`
 
 The CLI and TUI automatically load and merge enabled packs at startup; newly added classes and races will appear in selection lists, and appearance enums are unioned with pack-provided values.
+
+## Live Reload (dev)
+
+- Run `python scripts/dev_watch.py` to watch `character_creation/data/` and re-validate on changes.
+- Set `dev.live_reload: true` in `character_creation/data/dev_config.yaml` to auto-reload in the TUI.

--- a/character_creation_package/character_creation/data/dev_config.yaml
+++ b/character_creation_package/character_creation/data/dev_config.yaml
@@ -1,0 +1,3 @@
+dev:
+  live_reload: true
+  debounce_ms: 300

--- a/character_creation_package/character_creation/services/live_reload.py
+++ b/character_creation_package/character_creation/services/live_reload.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Callable
+import time
+
+import yaml
+from watchfiles import watch
+
+from ..loaders import (
+    stats_loader,
+    slots_loader,
+    appearance_loader,
+    resources_loader,
+    progression_loader,
+    classes_loader,
+    traits_loader,
+    items_loader,
+    races_loader,
+)
+from ..loaders import content_packs_loader
+from .validate_data import (
+    validate_stats,
+    validate_classes,
+    validate_traits,
+    validate_slots,
+    validate_items,
+    validate_races,
+    validate_appearance_fields,
+    validate_appearance_table,
+    validate_numeric_range,
+    validate_creation_limits,
+    validate_merged_catalogs,
+)
+
+
+class CatalogReloader:
+    def __init__(self, data_root: Path):
+        self.data_root = Path(data_root)
+        self.version = 0
+        self._last_ok: Dict[str, Any] | None = None
+
+    def _load_base(self) -> Dict[str, Any]:
+        dr = self.data_root
+        stats = stats_loader.load_stat_template(dr / "stats" / "stats.yaml")
+        slots = slots_loader.load_slot_template(dr / "slots.yaml")
+        fields = appearance_loader.load_appearance_fields(dr / "appearance" / "fields.yaml")
+        defaults = appearance_loader.load_appearance_defaults(dr / "appearance" / "defaults.yaml")
+        resources = resources_loader.load_resources(dr / "resources.yaml")
+        classes = classes_loader.load_class_catalog(dr / "classes.yaml")
+        traits = traits_loader.load_trait_catalog(dr / "traits.yaml")
+        items = items_loader.load_item_catalog(dr / "items.yaml")
+        races = races_loader.load_race_catalog(dr / "races.yaml")
+        progression = progression_loader.load_progression(dr / "progression.yaml")
+        with open(dr / "formulas.yaml", "r", encoding="utf-8") as f:
+            formulas = yaml.safe_load(f)
+        limits_path = dr / "creation_limits.yaml"
+        if limits_path.exists():
+            with open(limits_path, "r", encoding="utf-8") as f:
+                creation_limits = yaml.safe_load(f) or {}
+        else:
+            creation_limits = {}
+
+        # Optional content packs
+        packs_cfg_path = dr / "content_packs.yaml"
+        if packs_cfg_path.exists():
+            with open(packs_cfg_path, "r", encoding="utf-8") as f:
+                packs_cfg = yaml.safe_load(f) or {"enabled": [], "merge": {"on_conflict": "skip"}}
+        else:
+            packs_cfg = {"enabled": [], "merge": {"on_conflict": "skip"}}
+        merged_from_packs = content_packs_loader.load_and_merge_enabled_packs(dr, packs_cfg)
+
+        # Merge helper
+        def list_merge(base_list, add_list, key="id"):
+            if not isinstance(base_list, list):
+                base_list = []
+            seen = {x.get(key) for x in base_list if isinstance(x, dict)}
+            for it in add_list or []:
+                if isinstance(it, dict) and it.get(key) not in seen:
+                    base_list.append(it)
+                    seen.add(it.get(key))
+            return base_list
+
+        # Normalize loaders that may return list-only or dict wrappers
+        def ensure_dict_list(wrapper_key: str, data_obj: Any) -> Dict[str, Any]:
+            if isinstance(data_obj, dict) and wrapper_key in data_obj:
+                return {wrapper_key: list(data_obj[wrapper_key])}
+            if isinstance(data_obj, list):
+                return {wrapper_key: list(data_obj)}
+            return {wrapper_key: []}
+
+        classes = ensure_dict_list("classes", classes)
+        races = ensure_dict_list("races", races)
+        # traits should be mapping under 'traits'
+        if isinstance(traits, dict) and "traits" in traits:
+            traits = {"traits": dict(traits["traits"])}
+        elif isinstance(traits, dict):
+            traits = {"traits": dict(traits)}
+        else:
+            traits = {"traits": {}}
+        # items should be list under 'items'
+        if isinstance(items, dict) and "items" in items:
+            items = {
+                "items": (
+                    list(items["items"])
+                    if isinstance(items["items"], list)
+                    else list(items.values())
+                )
+            }
+        elif isinstance(items, list):
+            items = {"items": list(items)}
+        else:
+            items = {"items": []}
+
+        # Apply merged overlays
+        if "classes" in merged_from_packs:
+            classes = {
+                "classes": list_merge(classes.get("classes", []), merged_from_packs["classes"])
+            }
+        if "traits" in merged_from_packs:
+            merged_traits = dict(traits.get("traits", {}))
+            merged_traits.update(merged_from_packs["traits"])
+            traits = {"traits": merged_traits}
+        if "races" in merged_from_packs:
+            races = {"races": list_merge(races.get("races", []), merged_from_packs["races"])}
+        if "items" in merged_from_packs:
+            items = {"items": list_merge(items.get("items", []), merged_from_packs["items"])}
+
+        # Appearance tables union (base + packs)
+        appearance_tables: Dict[str, Any] = {}
+        tables_dir = dr / "appearance" / "tables"
+        if tables_dir.exists():
+            for p in tables_dir.glob("*.yaml"):
+                with open(p, "r", encoding="utf-8") as f:
+                    loaded = yaml.safe_load(f) or []
+                if isinstance(loaded, dict) and "values" in loaded:
+                    values = loaded.get("values") or []
+                elif isinstance(loaded, list):
+                    values = loaded
+                else:
+                    values = []
+                appearance_tables[p.stem] = values
+        if "appearance_tables" in merged_from_packs:
+            for k, vals in merged_from_packs["appearance_tables"].items():
+                base_vals = list(appearance_tables.get(k, []))
+                for v in vals or []:
+                    if v not in base_vals:
+                        base_vals.append(v)
+                appearance_tables[k] = base_vals
+
+        return {
+            "stats": stats,
+            "slots": slots,
+            "appearance_fields": fields,
+            "appearance_defaults": defaults,
+            "resources": resources,
+            "class_catalog": classes,
+            "trait_catalog": traits,
+            "items_catalog": items,
+            "race_catalog": races,
+            "appearance_tables": appearance_tables,
+            "progression": progression,
+            "formulas": formulas,
+            "creation_limits": creation_limits,
+        }
+
+    def _validate_all(self, cats: Dict[str, Any]) -> None:
+        validate_stats(cats["stats"])
+        validate_classes(cats["class_catalog"])
+        validate_traits(cats["trait_catalog"])
+        validate_slots(cats["slots"])
+        validate_items(cats["items_catalog"], cats["slots"])
+        validate_races(cats["race_catalog"])
+        validate_appearance_fields(cats["appearance_fields"])
+        # Validate one table and one range if present
+        dr = self.data_root
+        tables_dir = dr / "appearance" / "tables"
+        ranges_dir = dr / "appearance" / "ranges"
+        if tables_dir.exists():
+            for p in tables_dir.glob("*.yaml"):
+                with open(p, "r", encoding="utf-8") as f:
+                    validate_appearance_table(yaml.safe_load(f), p.stem)
+                break
+        if ranges_dir.exists():
+            for p in ranges_dir.glob("*.yaml"):
+                with open(p, "r", encoding="utf-8") as f:
+                    validate_numeric_range(yaml.safe_load(f), p.stem)
+                break
+        validate_creation_limits(cats.get("creation_limits", {}))
+        validate_merged_catalogs(
+            {
+                "classes": cats["class_catalog"].get("classes", []),
+                "traits": cats["trait_catalog"].get("traits", {}),
+                "races": cats["race_catalog"].get("races", []),
+                "items": cats["items_catalog"].get("items", []),
+                "appearance_tables": cats["appearance_tables"],
+            }
+        )
+
+    def reload_once(self) -> Dict[str, Any]:
+        cats = self._load_base()
+        self._validate_all(cats)
+        self.version += 1
+        self._last_ok = cats
+        return cats
+
+    def watch(
+        self, callback: Callable[[Dict[str, Any], int, list], None], debounce_ms: int = 300
+    ) -> None:
+        data_dir = str(self.data_root)
+        last_emit = 0.0
+        for changes in watch(data_dir, recursive=True):
+            now = time.time()
+            if (now - last_emit) * 1000 < debounce_ms:
+                continue
+            last_emit = now
+            try:
+                cats = self.reload_once()
+                callback(cats, self.version, list(changes))
+            except Exception as e:  # noqa: BLE001
+                print(f"[LiveReload] Validation error: {e}")

--- a/character_creation_package/pyproject.toml
+++ b/character_creation_package/pyproject.toml
@@ -33,7 +33,8 @@ dev = [
     "pytest>=8.0",
     "black",
     "ruff",
-    "pre-commit"
+    "pre-commit",
+    "watchfiles>=0.21"
 ]
 
 [tool.black]

--- a/character_creation_package/scripts/dev_watch.py
+++ b/character_creation_package/scripts/dev_watch.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from character_creation.services.live_reload import CatalogReloader
+
+
+def main() -> None:
+    dr = Path(__file__).parents[1] / "character_creation" / "data"
+    rel = CatalogReloader(dr)
+    print("Watching data/ for changes... Ctrl+C to stop.")
+
+    def on_update(cats, version, changes):  # noqa: ANN001
+        classes = len(cats["class_catalog"].get("classes", []))
+        traits = len(cats["trait_catalog"].get("traits", {}))
+        races = len(cats["race_catalog"].get("races", []))
+        items = len(cats["items_catalog"].get("items", []))
+        print(
+            f"[v{version}] Reload OK — classes={classes}, traits={traits}, races={races}, items={items}. Changed: {len(changes)}"
+        )
+
+    try:
+        rel.watch(on_update, debounce_ms=300)
+    except KeyboardInterrupt:
+        print("Stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/character_creation_package/tests/test_live_reload_reloader.py
+++ b/character_creation_package/tests/test_live_reload_reloader.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from character_creation.services.live_reload import CatalogReloader
+
+
+def test_reload_once_loads_and_validates():
+    dr = Path("character_creation/data")
+    rel = CatalogReloader(dr)
+    cats = rel.reload_once()
+    assert "class_catalog" in cats and "trait_catalog" in cats
+    assert isinstance(cats["class_catalog"].get("classes", []), list)
+    assert isinstance(cats["trait_catalog"].get("traits", {}), dict)
+    assert rel.version >= 1


### PR DESCRIPTION
updates for phase 7 of cc patching, which includes: 

# cc_patch_7 — One-shot Composer Prompt (Live Reload for Dev)

ENVIRONMENT
- Use the **worldseed** Python environment/interpreter for all indexing, analysis, and execution (not “base”).
  - Windows: select `.venv\Scripts\python.exe` (worldseed) in VS Code.
  - macOS/Linux: select `.venv/bin/python`.

SYSTEM / ROLE
- You are an expert Python game-systems engineer.
- Python 3.12, Black, Ruff, pytest. Minimal, surgical edits. Do not rename or move files unless instructed.

PROJECT CONTEXT
- This repo (character_creation_package) is a YAML-driven character creation system.
- After cc_patch_1..6 we have: content packs, validators, races & appearance, save/load.
- This patch adds a **dev-only live reload** path that:
  1) Watches YAML & content packs
  2) Reloads & re-merges catalogs
  3) Runs validators
  4) Updates the TUI without restart
  5) Provides a simple CLI watcher

GOALS
A) Live reload service with watch, merge, validate, versioning.  
B) TUI: optional background watcher that updates in-memory catalogs & list widgets.  
C) CLI: dev watcher script that prints validation status and counts.  
D) Unit test the reloader’s non-watching path (no long-running tests).

DEPENDENCIES
1) Update `pyproject.toml` to include **watchfiles** in dev extras:
   - Under `[project.optional-dependencies]`, ensure a `dev` list exists and append:
     `"watchfiles>=0.21"`
   - Example:
     [project.optional-dependencies]
     dev = [
       "pytest",
       "black",
       "ruff",
       "pre-commit",
       "mypy",
       "watchfiles>=0.21"
     ]

FILES TO ADD / MODIFY

2) ADD dev config: `character_creation/data/dev_config.yaml`
---
dev:
  live_reload: true
  debounce_ms: 300
---

3) ADD service: `character_creation/services/live_reload.py`
- Implement a small reloader that:
  - Loads base YAML + content packs (using existing loaders + content_packs_loader)
  - Merges overlays and appearance tables
  - Validates with existing validators
  - Tracks a monotonic `version` on each successful reload
  - API:
    * class CatalogReloader(data_root: Path)
      - reload_once() -> Dict[str, Any]   # returns current catalogs on success; raises on validation error
      - watch(callback, debounce_ms: int = 300) -> None
        # uses watchfiles to monitor data dir; on changes:
        #   reload_once(); callback(catalogs, version, list_of_changes)
- Provide this skeleton (fill in any small gaps with correct imports/types):

from __future__ import annotations
from pathlib import Path
from typing import Any, Dict, Callable
from watchfiles import watch
import yaml

from character_creation.loaders import (
    stats_loader, slots_loader, appearance_loader, resources_loader, progression_loader,
    classes_loader, traits_loader, items_loader, races_loader
)
from character_creation.loaders import content_packs_loader
from character_creation.services.validate_data import (
    validate_stats, validate_classes, validate_traits, validate_slots, validate_items,
    validate_races, validate_appearance_fields, validate_appearance_table,
    validate_numeric_range, validate_creation_limits, validate_merged_catalogs
)

class CatalogReloader:
    def __init__(self, data_root: Path):
        self.data_root = data_root
        self.version = 0
        self._last_ok: Dict[str, Any] | None = None

    def _load_base(self) -> Dict[str, Any]:
        dr = self.data_root
        stats = stats_loader.load_stat_template(dr / "stats" / "stats.yaml")
        slots = slots_loader.load_slot_template(dr / "slots.yaml")
        fields = appearance_loader.load_appearance_fields(dr / "appearance" / "fields.yaml")
        defaults = appearance_loader.load_appearance_defaults(dr / "appearance" / "defaults.yaml")
        resources = resources_loader.load_resources(dr / "resources.yaml")
        classes = classes_loader.load_class_catalog(dr / "classes.yaml")
        traits = traits_loader.load_trait_catalog(dr / "traits.yaml")
        items = items_loader.load_item_catalog(dr / "items.yaml")
        races = races_loader.load_race_catalog(dr / "races.yaml")
        progression = progression_loader.load_progression(dr / "progression.yaml")
        formulas = yaml.safe_load(open(dr / "formulas.yaml", "r", encoding="utf-8"))
        limits_path = dr / "creation_limits.yaml"
        creation_limits = yaml.safe_load(open(limits_path, "r", encoding="utf-8")) if limits_path.exists() else {}

        # Optional content packs
        packs_cfg_path = dr / "content_packs.yaml"
        packs_cfg = yaml.safe_load(open(packs_cfg_path, "r", encoding="utf-8")) if packs_cfg_path.exists() else {"enabled": [], "merge": {"on_conflict": "skip"}}
        merged_from_packs = content_packs_loader.load_and_merge_enabled_packs(dr, packs_cfg)

        # Merge helper
        def list_merge(base_list, add_list, key="id"):
            if not isinstance(base_list, list): base_list = []
            seen = {x.get(key) for x in base_list if isinstance(x, dict)}
            for it in add_list or []:
                if isinstance(it, dict) and it.get(key) not in seen:
                    base_list.append(it)
                    seen.add(it.get(key))
            return base_list

        # Apply merged overlays
        if "classes" in merged_from_packs:
            classes = {"classes": list_merge(classes.get("classes", []), merged_from_packs["classes"])}
        if "traits" in merged_from_packs:
            merged_traits = dict(traits.get("traits", {}))
            merged_traits.update(merged_from_packs["traits"])
            traits = {"traits": merged_traits}
        if "races" in merged_from_packs:
            races = {"races": list_merge(races.get("races", []), merged_from_packs["races"])}
        if "items" in merged_from_packs:
            items = {"items": list_merge(items.get("items", []), merged_from_packs["items"])}

        # Appearance tables union (base + packs)
        appearance_tables = {}
        tables_dir = dr / "appearance" / "tables"
        if tables_dir.exists():
            for p in tables_dir.glob("*.yaml"):
                appearance_tables[p.stem] = yaml.safe_load(open(p, "r", encoding="utf-8")) or []
        if "appearance_tables" in merged_from_packs:
            for k, vals in merged_from_packs["appearance_tables"].items():
                base_vals = appearance_tables.get(k, [])
                for v in vals:
                    if v not in base_vals:
                        base_vals.append(v)
                appearance_tables[k] = base_vals

        return {
            "stats": stats,
            "slots": slots,
            "appearance_fields": fields,
            "appearance_defaults": defaults,
            "resources": resources,
            "class_catalog": classes,
            "trait_catalog": traits,
            "items_catalog": items,
            "race_catalog": races,
            "appearance_tables": appearance_tables,
            "progression": progression,
            "formulas": formulas,
            "creation_limits": creation_limits,
        }

    def _validate_all(self, cats: Dict[str, Any]) -> None:
        validate_stats(cats["stats"])
        validate_classes(cats["class_catalog"])
        validate_traits(cats["trait_catalog"])
        validate_slots(cats["slots"])
        validate_items(cats["items_catalog"], cats["slots"])
        validate_races(cats["race_catalog"])
        validate_appearance_fields(cats["appearance_fields"])
        # One table, one range if present
        dr = self.data_root
        tables_dir = dr / "appearance" / "tables"
        ranges_dir = dr / "appearance" / "ranges"
        if tables_dir.exists():
            for p in tables_dir.glob("*.yaml"):
                validate_appearance_table(yaml.safe_load(open(p, "r", encoding="utf-8")), p.stem)
                break
        if ranges_dir.exists():
            for p in ranges_dir.glob("*.yaml"):
                validate_numeric_range(yaml.safe_load(open(p, "r", encoding="utf-8")), p.stem)
                break
        validate_creation_limits(cats.get("creation_limits", {}))
        validate_merged_catalogs({
            "classes": cats["class_catalog"].get("classes", []),
            "traits": cats["trait_catalog"].get("traits", {}),
            "races": cats["race_catalog"].get("races", []),
            "items": cats["items_catalog"].get("items", []),
            "appearance_tables": cats["appearance_tables"],
        })

    def reload_once(self) -> Dict[str, Any]:
        cats = self._load_base()
        self._validate_all(cats)
        self.version += 1
        self._last_ok = cats
        return cats

    def watch(self, callback: Callable[[Dict[str, Any], int, list], None], debounce_ms: int = 300) -> None:
        data_dir = str(self.data_root)
        last_emit = 0.0
        import time
        for changes in watch(data_dir, recursive=True):
            now = time.time()
            if (now - last_emit) * 1000 < debounce_ms:
                continue
            last_emit = now
            try:
                cats = self.reload_once()
                callback(cats, self.version, list(changes))
            except Exception as e:
                print(f"[LiveReload] Validation error: {e}")

4) MODIFY TUI app: `character_creation/ui/textual/app.py`
- Read `character_creation/data/dev_config.yaml` at startup.
- If `dev.live_reload` is true:
  * Instantiate `CatalogReloader(data_root)` where `data_root = Path(__file__).parents[2] / "data"`
  * Define method `apply_catalogs(cats: dict)` that updates in-memory catalogs the TUI uses (class_catalog, trait_catalog, race_catalog, appearance tables, limits, etc.) and refreshes any list widgets if mounted (class list, race list, trait list). Safe-guard if views aren’t mounted yet; just store catalogs.
  * Start a background task/thread to `reloader.watch(self._on_catalogs_updated, debounce_ms=config['dev']['debounce_ms'])`
  * Implement `_on_catalogs_updated(cats, version, changes)` to call `apply_catalogs(cats)` and optionally show a small footer notice like “Data reloaded (v{version})”.
- Keep changes minimal; do not refactor screens heavily. If screens cache lists, rebuild them on update or on next focus.

5) ADD CLI watcher: `scripts/dev_watch.py`
- Simple script that watches data/ and prints a one-line status on each reload:

from pathlib import Path
from character_creation.services.live_reload import CatalogReloader

def main():
    dr = Path(__file__).parents[1] / "character_creation" / "data"
    rel = CatalogReloader(dr)
    print("Watching data/ for changes... Ctrl+C to stop.")
    def on_update(cats, version, changes):
        classes = len(cats["class_catalog"].get("classes", []))
        traits  = len(cats["trait_catalog"].get("traits", {}))
        races   = len(cats["race_catalog"].get("races", []))
        items   = len(cats["items_catalog"].get("items", []))
        print(f"[v{version}] Reload OK — classes={classes}, traits={traits}, races={races}, items={items}. Changed: {len(changes)}")
    try:
        rel.watch(on_update, debounce_ms=300)
    except KeyboardInterrupt:
        print("Stopped.")

if __name__ == "__main__":
    main()

6) ADD TEST: `tests/test_live_reload_reloader.py`
- Unit test for `reload_once()` (no long-running watch loop):

from pathlib import Path
from character_creation.services.live_reload import CatalogReloader

def test_reload_once_loads_and_validates():
    dr = Path("character_creation/data")
    rel = CatalogReloader(dr)
    cats = rel.reload_once()
    assert "class_catalog" in cats and "trait_catalog" in cats
    assert isinstance(cats["class_catalog"].get("classes", []), list)
    assert isinstance(cats["trait_catalog"].get("traits", {}), dict)
    assert rel.version >= 1

7) README.md — add a short “Live Reload (dev)” section:
- “Run `python scripts/dev_watch.py` to watch `character_creation/data/` and re-validate on changes.”
- “Set `dev.live_reload: true` in `character_creation/data/dev_config.yaml` to auto-reload in the TUI.”

8) Makefile — optional target:
dev-watch:
\tpython scripts/dev_watch.py

ACCEPTANCE CRITERIA
- `pre-commit run --all-files; pytest -q` passes.
- `python scripts/dev_watch.py` prints “[v1] Reload OK …” and updates on YAML edits.
- With `dev.live_reload: true`, the TUI updates lists/labels when data changes (e.g., add a class in a pack; it appears without restart).

CONSTRAINTS & STYLE
- Python 3.12; Black/Ruff; minimal changes.
- Live reload is **dev-only**; does nothing unless enabled.
- On validation error, keep last good catalogs in app; print error to console.

PATCH PLAN (execution order)
1) Add dev_config.yaml; add watchfiles to pyproject dev extras.
2) Implement services/live_reload.py.
3) Wire TUI app to optionally use reloader (apply_catalogs + background thread).
4) Add scripts/dev_watch.py.
5) Add tests/test_live_reload_reloader.py.
6) README + Makefile tweaks.
7) Run pre-commit + pytest; iterate until green.

FINAL COMMANDS (worldseed env)
pre-commit run --all-files; pytest -q
