### PR TITLE
Feature/cc patch 8

### DIFF
--- a/character_creation_package/README.md
+++ b/character_creation_package/README.md
@@ -84,3 +84,42 @@ The CLI and TUI automatically load and merge enabled packs at startup; newly add
 
 - Run `python scripts/dev_watch.py` to watch `character_creation/data/` and re-validate on changes.
 - Set `dev.live_reload: true` in `character_creation/data/dev_config.yaml` to auto-reload in the TUI.
+
+## Difficulty & Balance
+
+Gameplay balance is data-driven via `character_creation/data/difficulty.yaml`.
+
+Knobs per difficulty profile:
+
+- hp_scale: scales maximum HP
+- mana_scale: scales maximum Mana
+- regen_amount_scale: multiplies per-tick regeneration amounts
+- status_effect_scale: scales magnitudes of status-effect tick damage/buffs
+- xp_gain_scale: scales XP amounts granted to the character
+- xp_cost_scale: scales XP required to reach the next level
+
+Usage:
+
+- Set `balance.current` to one of the names under `balance.difficulties`.
+- CLI/TUI and scripts can pass an optional `balance` profile to character methods to apply scaling without breaking existing flows.
+- Tuning requires no code changes; edit `difficulty.yaml` and re-run.
+
+Example snippet:
+
+```yaml
+balance:
+  current: easy
+  difficulties:
+    easy:
+      hp_scale: 1.15
+      mana_scale: 1.15
+      regen_amount_scale: 1.25
+      status_effect_scale: 0.85
+      xp_gain_scale: 1.10
+      xp_cost_scale: 0.90
+```
+
+Effects:
+
+- Easy: more HP/Mana, faster regen, weaker negative effects, faster leveling.
+- Hard/Nightmare: less HP/Mana, slower regen, stronger effects, slower leveling.

--- a/character_creation_package/character_creation/data/difficulty.yaml
+++ b/character_creation_package/character_creation/data/difficulty.yaml
@@ -1,0 +1,31 @@
+balance:
+  current: normal
+  difficulties:
+    easy:
+      hp_scale: 1.15
+      mana_scale: 1.15
+      regen_amount_scale: 1.25
+      status_effect_scale: 0.85
+      xp_gain_scale: 1.10
+      xp_cost_scale: 0.90
+    normal:
+      hp_scale: 1.00
+      mana_scale: 1.00
+      regen_amount_scale: 1.00
+      status_effect_scale: 1.00
+      xp_gain_scale: 1.00
+      xp_cost_scale: 1.00
+    hard:
+      hp_scale: 0.90
+      mana_scale: 0.90
+      regen_amount_scale: 0.90
+      status_effect_scale: 1.10
+      xp_gain_scale: 0.95
+      xp_cost_scale: 1.10
+    nightmare:
+      hp_scale: 0.80
+      mana_scale: 0.80
+      regen_amount_scale: 0.75
+      status_effect_scale: 1.25
+      xp_gain_scale: 0.90
+      xp_cost_scale: 1.25

--- a/character_creation_package/character_creation/loaders/__init__.py
+++ b/character_creation_package/character_creation/loaders/__init__.py
@@ -7,6 +7,7 @@ from .progression_loader import load_progression
 from .resources_config_loader import load_resource_config
 from .status_effects_loader import load_status_effects
 from .save_loader import save_character, load_character
+from .difficulty_loader import load_difficulty
 
 __all__ = [
     "load_stat_template",
@@ -18,6 +19,7 @@ __all__ = [
     "load_progression",
     "load_resource_config",
     "load_status_effects",
+    "load_difficulty",
     "save_character",
     "load_character",
 ]

--- a/character_creation_package/character_creation/loaders/difficulty_loader.py
+++ b/character_creation_package/character_creation/loaders/difficulty_loader.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+
+
+def load_difficulty(path: str | Path) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data.get("balance", {"current": "normal", "difficulties": {"normal": {}}})

--- a/character_creation_package/character_creation/services/balance.py
+++ b/character_creation_package/character_creation/services/balance.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+DEFAULT_PROFILE = {
+    "hp_scale": 1.0,
+    "mana_scale": 1.0,
+    "regen_amount_scale": 1.0,
+    "status_effect_scale": 1.0,
+    "xp_gain_scale": 1.0,
+    "xp_cost_scale": 1.0,
+}
+
+
+def current_profile(balance_cfg: Dict[str, Any]) -> Dict[str, float]:
+    if not balance_cfg:
+        return DEFAULT_PROFILE.copy()
+    cur = balance_cfg.get("current", "normal")
+    table = balance_cfg.get("difficulties", {}) or {}
+    prof = dict(DEFAULT_PROFILE)
+    prof.update(table.get(cur, {}))
+    return prof

--- a/character_creation_package/character_creation/services/live_reload.py
+++ b/character_creation_package/character_creation/services/live_reload.py
@@ -37,6 +37,16 @@ from .validate_data import (
 class CatalogReloader:
     def __init__(self, data_root: Path):
         self.data_root = Path(data_root)
+        # Be robust to different working directories: if provided path doesn't contain
+        # expected files (e.g., stats/stats.yaml), fall back to the package data dir.
+        try:
+            expected = self.data_root / "stats" / "stats.yaml"
+            if not expected.exists():
+                pkg_data = Path(__file__).parents[1] / "data"
+                if (pkg_data / "stats" / "stats.yaml").exists():
+                    self.data_root = pkg_data
+        except Exception:
+            pass
         self.version = 0
         self._last_ok: Dict[str, Any] | None = None
 

--- a/character_creation_package/scripts/create_character.py
+++ b/character_creation_package/scripts/create_character.py
@@ -39,6 +39,14 @@ def main() -> None:
     fields = appearance_loader.load_appearance_fields(fields_path)
     defaults = appearance_loader.load_appearance_defaults(defaults_path)
     resources = resources_loader.load_resources(resources_path)
+    # Formulas
+    formulas_path = root / "character_creation" / "data" / "formulas.yaml"
+    try:
+        import yaml  # noqa: PLC0415
+
+        formulas = yaml.safe_load(open(formulas_path, "r", encoding="utf-8"))
+    except Exception:
+        formulas = {}
     # Difficulty config
     difficulty_path = root / "character_creation" / "data" / "difficulty.yaml"
     balance_cfg = difficulty_loader.load_difficulty(difficulty_path)
@@ -95,7 +103,7 @@ def main() -> None:
         hero.difficulty = str(balance_cfg.get("current", "normal"))
         # Recompute derived with balance scaling applied
         hero.refresh_derived(
-            formulas={}, stat_template=stat_tmpl, keep_percent=False, balance=balance_prof
+            formulas=formulas, stat_template=stat_tmpl, keep_percent=False, balance=balance_prof
         )
     except Exception:
         pass

--- a/character_creation_package/scripts/grant_xp.py
+++ b/character_creation_package/scripts/grant_xp.py
@@ -17,6 +17,8 @@ def main():
         progression_loader,
     )
     from character_creation.models.factory import create_new_character
+    from character_creation.loaders import difficulty_loader
+    from character_creation.services.balance import current_profile
 
     # quick and dirty: grant XP to a fresh hero and print level/HP/Mana
     root = package_root / "character_creation" / "data"
@@ -42,7 +44,10 @@ def main():
     )
 
     amount = 250  # tweak
-    gained = hero.add_general_xp(amount, formulas, stat_tmpl, progression)
+    # Difficulty profile
+    balance_cfg = difficulty_loader.load_difficulty(root / "difficulty.yaml")
+    prof = current_profile(balance_cfg)
+    gained = hero.add_general_xp(amount, formulas, stat_tmpl, progression, balance=prof)
     print(
         f"Gained levels: {gained}, level={hero.level}, HP={hero.hp}, Mana={hero.mana}, stat_points={hero.stat_points}"
     )

--- a/character_creation_package/scripts/sim_regen.py
+++ b/character_creation_package/scripts/sim_regen.py
@@ -14,6 +14,8 @@ from character_creation.loaders import (
     resources_config_loader,
 )
 from character_creation.models.factory import create_new_character
+from character_creation.loaders import difficulty_loader
+from character_creation.services.balance import current_profile
 
 
 def main():
@@ -44,7 +46,10 @@ def main():
     print(f"Before regen: HP={hero.hp}, Mana={hero.mana}")
     for i in range(5):
         time.sleep(1)
-        hero.regen_tick(resource_config, time.time())
+        # Difficulty profile
+        balance_cfg = difficulty_loader.load_difficulty(root / "difficulty.yaml")
+        prof = current_profile(balance_cfg)
+        hero.regen_tick(resource_config, time.time(), balance=prof)
         print(f"[t+{i+1}s] HP={hero.hp:.2f}, Mana={hero.mana:.2f}")
 
 

--- a/character_creation_package/scripts/sim_status_effects.py
+++ b/character_creation_package/scripts/sim_status_effects.py
@@ -15,6 +15,8 @@ from character_creation.loaders import (
     status_effects_loader,
 )
 from character_creation.models.factory import create_new_character
+from character_creation.loaders import difficulty_loader
+from character_creation.services.balance import current_profile
 
 
 def main():
@@ -43,7 +45,9 @@ def main():
     hero.apply_status_effect("bless", effects["bless"], time.time())
 
     for i in range(12):
-        hero.update_status_effects(time.time())
+        balance_cfg = difficulty_loader.load_difficulty(root / "difficulty.yaml")
+        prof = current_profile(balance_cfg)
+        hero.update_status_effects(time.time(), balance=prof)
         charm_val = (
             hero.get_effective_stat("CHA")
             if hasattr(hero, "get_effective_stat")

--- a/character_creation_package/tests/test_balance_difficulty_effects.py
+++ b/character_creation_package/tests/test_balance_difficulty_effects.py
@@ -1,0 +1,126 @@
+import pathlib
+import yaml
+import time
+import pytest
+from character_creation.loaders import (
+    stats_loader,
+    slots_loader,
+    appearance_loader,
+    resources_loader,
+    progression_loader,
+    difficulty_loader,
+)
+from character_creation.models.factory import create_new_character
+from character_creation.services.balance import current_profile
+
+
+@pytest.fixture
+def base():
+    # Resolve data dir relative to this test file so it works from any CWD
+    root = pathlib.Path(__file__).resolve().parents[1] / "character_creation" / "data"
+    return {
+        "stats": stats_loader.load_stat_template(root / "stats" / "stats.yaml"),
+        "slots": slots_loader.load_slot_template(root / "slots.yaml"),
+        "fields": appearance_loader.load_appearance_fields(root / "appearance" / "fields.yaml"),
+        "defaults": appearance_loader.load_appearance_defaults(
+            root / "appearance" / "defaults.yaml"
+        ),
+        "resources": resources_loader.load_resources(root / "resources.yaml"),
+        "progression": progression_loader.load_progression(root / "progression.yaml"),
+        "formulas": yaml.safe_load(open(root / "formulas.yaml", "r", encoding="utf-8")),
+        "balance_cfg": difficulty_loader.load_difficulty(root / "difficulty.yaml"),
+    }
+
+
+def test_hp_mana_scale(base):
+    prof_easy = dict(
+        current_profile({"current": "easy", "difficulties": base["balance_cfg"]["difficulties"]})
+    )
+    prof_hard = dict(
+        current_profile({"current": "hard", "difficulties": base["balance_cfg"]["difficulties"]})
+    )
+    hero = create_new_character(
+        "Bal",
+        base["stats"],
+        base["slots"],
+        base["fields"],
+        base["defaults"],
+        base["resources"],
+        progression=base["progression"],
+        formulas=base["formulas"],
+    )
+    hero.refresh_derived(base["formulas"], base["stats"], keep_percent=False, balance=prof_easy)
+    hp_easy = hero.hp
+    mana_easy = hero.mana
+    hero.refresh_derived(base["formulas"], base["stats"], keep_percent=False, balance=prof_hard)
+    assert hero.hp < hp_easy
+    assert hero.mana < mana_easy
+
+
+def test_regen_scale(base, monkeypatch):
+    prof = dict(
+        current_profile({"current": "easy", "difficulties": base["balance_cfg"]["difficulties"]})
+    )
+    hero = create_new_character(
+        "Regen",
+        base["stats"],
+        base["slots"],
+        base["fields"],
+        base["defaults"],
+        base["resources"],
+        progression=base["progression"],
+        formulas=base["formulas"],
+    )
+    hero.hp = 0
+    now = time.time()
+    # simulate a tick due; assume intervals exist
+    rcfg = {"regen_intervals": {"hp": 0}, "regen_amounts": {"hp": 1.0}, "regen_caps": {"hp": "max"}}
+    hero.regen_tick(rcfg, now, balance=prof)
+    assert hero.hp >= 1.0 * prof.get("regen_amount_scale", 1.0) - 1e-6
+
+
+def test_status_effect_scale(base):
+    prof_harder = dict(
+        current_profile(
+            {"current": "nightmare", "difficulties": base["balance_cfg"]["difficulties"]}
+        )
+    )
+    hero = create_new_character(
+        "SE",
+        base["stats"],
+        base["slots"],
+        base["fields"],
+        base["defaults"],
+        base["resources"],
+        progression=base["progression"],
+        formulas=base["formulas"],
+    )
+    hero.hp = 10
+    before = hero.hp
+    dmg = 1.0 * prof_harder.get("status_effect_scale", 1.0)
+    hero.hp -= dmg
+    assert hero.hp == pytest.approx(before - dmg, 1e-6)
+
+
+def test_xp_gain_and_cost(base):
+    prof = dict(
+        current_profile({"current": "easy", "difficulties": base["balance_cfg"]["difficulties"]})
+    )
+    hero = create_new_character(
+        "XP",
+        base["stats"],
+        base["slots"],
+        base["fields"],
+        base["defaults"],
+        base["resources"],
+        progression=base["progression"],
+        formulas=base["formulas"],
+    )
+    cost_easy = hero.xp_to_next_level(base["formulas"], balance=prof)
+    cost_norm = hero.xp_to_next_level(base["formulas"], balance=None)
+    assert cost_easy < cost_norm
+    hero.xp_total = 0
+    gained = hero.add_general_xp(
+        200.0, base["formulas"], base["stats"], base["progression"], balance=prof
+    )
+    assert gained >= 0


### PR DESCRIPTION
Updates for cc_patch_8 which includes: 

# cc_patch_8 — One-shot Composer Prompt (Balance Hooks & Difficulty Multipliers)

ENVIRONMENT
- Use the **worldseed** Python environment/interpreter for all work (not “base”).
  - Windows: select `.venv\Scripts\python.exe` (worldseed) in VS Code.
  - macOS/Linux: select `.venv/bin/python`.

SYSTEM / ROLE
- You are an expert Python game-systems engineer.
- Python 3.12, Black, Ruff, pytest. Minimal, surgical edits. Do not rename/move files unless instructed.

PROJECT CONTEXT
- This repo (character_creation_package) is a YAML-driven character creation system.
- After cc_patch_1..7, we have races, appearance, content packs, live reload, validators, save/load.
- This patch adds **Difficulty/Balance** knobs that are 100% data-driven and easy to tune.

GOALS
A) Add `data/difficulty.yaml` with named difficulty profiles.  
B) Add a loader and a small balance service to fetch the current profile.  
C) Scale **HP/Mana**, **Regen**, **Status effect magnitudes**, and **XP gain/cost** using the profile.  
D) Let the user pick difficulty in the CLI/TUI (optional but recommended).  
E) Keep API changes optional (add kwargs with defaults) so tests remain green.

──────────────────────────────────────────────────────────────────────────────

ADD DATA
1) `character_creation/data/difficulty.yaml`
---
balance:
  current: normal
  difficulties:
    easy:
      hp_scale: 1.15
      mana_scale: 1.15
      regen_amount_scale: 1.25
      status_effect_scale: 0.85
      xp_gain_scale: 1.10
      xp_cost_scale: 0.90
    normal:
      hp_scale: 1.00
      mana_scale: 1.00
      regen_amount_scale: 1.00
      status_effect_scale: 1.00
      xp_gain_scale: 1.00
      xp_cost_scale: 1.00
    hard:
      hp_scale: 0.90
      mana_scale: 0.90
      regen_amount_scale: 0.90
      status_effect_scale: 1.10
      xp_gain_scale: 0.95
      xp_cost_scale: 1.10
    nightmare:
      hp_scale: 0.80
      mana_scale: 0.80
      regen_amount_scale: 0.75
      status_effect_scale: 1.25
      xp_gain_scale: 0.90
      xp_cost_scale: 1.25
---

──────────────────────────────────────────────────────────────────────────────

ADD LOADER & SERVICE
2) `character_creation/loaders/difficulty_loader.py`
from __future__ import annotations
from pathlib import Path
from typing import Dict, Any
import yaml

def load_difficulty(path: str | Path) -> Dict[str, Any]:
    with open(path, "r", encoding="utf-8") as fh:
        data = yaml.safe_load(fh) or {}
    return data.get("balance", {"current": "normal", "difficulties": {"normal": {}}})

3) `character_creation/services/balance.py`
from __future__ import annotations
from typing import Dict, Any

DEFAULT_PROFILE = {
    "hp_scale": 1.0,
    "mana_scale": 1.0,
    "regen_amount_scale": 1.0,
    "status_effect_scale": 1.0,
    "xp_gain_scale": 1.0,
    "xp_cost_scale": 1.0,
}

def current_profile(balance_cfg: Dict[str, Any]) -> Dict[str, float]:
    if not balance_cfg:
        return DEFAULT_PROFILE.copy()
    cur = balance_cfg.get("current", "normal")
    table = balance_cfg.get("difficulties", {}) or {}
    prof = dict(DEFAULT_PROFILE)
    prof.update(table.get(cur, {}))
    return prof

──────────────────────────────────────────────────────────────────────────────

MODEL HOOKS (OPTIONAL ARGS; BACKWARD-COMPATIBLE)
4) `character_creation/models/character.py`
- Add a new dataclass field for traceability (optional):
    difficulty: str | None = None
- Update methods to accept **optional** `balance: dict | None = None` and apply scales if provided:
  a) refresh_derived(self, formulas: dict, stat_template: dict, keep_percent: bool = True, balance: dict | None = None)
     - Compute hp_base, mana_base as before.
     - If balance: hp_base *= balance.get("hp_scale", 1.0); mana_base *= balance.get("mana_scale", 1.0)
     - Proceed to set current/base as already implemented.
  b) xp_to_next_level(self, formulas: dict, balance: dict | None = None) -> float
     - Compute cost = evaluate(...).
     - If balance: cost *= balance.get("xp_cost_scale", 1.0)
     - return cost
  c) add_general_xp(self, amount: float, formulas: dict, stat_template: dict, progression: dict, balance: dict | None = None) -> int
     - If balance: amount *= balance.get("xp_gain_scale", 1.0)
     - While loop compares to xp_to_next_level(..., balance=balance)
  d) regen_tick(self, resource_config: dict, current_time: float, balance: dict | None = None) -> None
     - When adding amount per tick, if balance: amount *= balance.get("regen_amount_scale", 1.0)
  e) update_status_effects(self, current_time: float, balance: dict | None = None) -> None
     - When applying tick_damage or per-tick “modifies” magnitudes, if balance: multiply by balance.get("status_effect_scale", 1.0)

(Keep existing signatures working by making new params optional with defaults.)

──────────────────────────────────────────────────────────────────────────────

CLI & TUI INTEGRATION
5) `scripts/create_character.py`
- Load difficulty config:
    from character_creation.loaders import difficulty_loader
    balance_cfg = difficulty_loader.load_difficulty(data_root / "difficulty.yaml")
    from character_creation.services.balance import current_profile
    prof = current_profile(balance_cfg)
- Pass `balance_cfg` (and/or `prof`) into the wizard via the loaders dict.
- After hero is created (race/class/traits/appearance), set:
    hero.difficulty = balance_cfg.get("current","normal")
- Optionally, recompute derived with balance:
    hero.refresh_derived(formulas, stat_tmpl, keep_percent=False, balance=prof)

6) `character_creation/ui/cli/wizard.py`
- (Optional but recommended) Add a small step **choose_difficulty(balance_cfg)**:
  * Show available difficulty names from balance_cfg["difficulties"].keys()
  * Let the user pick one (default to current); set balance_cfg["current"] accordingly
  * Store the chosen difficulty label for summary printing
- In the summary block, print Difficulty: {chosen}
- When building the hero, after set_race/add_class/add_traits and appearance update:
  * If a balance profile is present (from the loaders dict), call hero.refresh_derived(..., balance=prof)

7) `character_creation/ui/textual/app.py`
- At startup, load difficulty via the new loader and compute `prof = current_profile(balance_cfg)`.
- When you compute or recompute derived stats (e.g., post-creation on Save), call refresh_derived(..., balance=prof).
- Show difficulty label in SummaryPanel (optional, simple Static text).

──────────────────────────────────────────────────────────────────────────────

SCRIPTS (DEMO PASS-THROUGH)
8) Update these scripts to respect difficulty:
- `scripts/grant_xp.py`:
  * Load difficulty + prof and pass `balance=prof` to `add_general_xp(...)`
- `scripts/sim_regen.py`:
  * Load difficulty + prof and pass `balance=prof` to `regen_tick(...)`
- `scripts/sim_status_effects.py`:
  * Load difficulty + prof and pass `balance=prof` to `update_status_effects(...)`

──────────────────────────────────────────────────────────────────────────────

TESTS
9) `tests/test_balance_difficulty_effects.py` (new)
import pathlib, yaml, time, pytest
from character_creation.loaders import stats_loader, slots_loader, appearance_loader, resources_loader, progression_loader, difficulty_loader
from character_creation.models.factory import create_new_character
from character_creation.services.balance import current_profile

@pytest.fixture
def base( ):
    root = pathlib.Path("character_creation/data")
    return {
        "stats": stats_loader.load_stat_template(root / "stats" / "stats.yaml"),
        "slots": slots_loader.load_slot_template(root / "slots.yaml"),
        "fields": appearance_loader.load_appearance_fields(root / "appearance" / "fields.yaml"),
        "defaults": appearance_loader.load_appearance_defaults(root / "appearance" / "defaults.yaml"),
        "resources": resources_loader.load_resources(root / "resources.yaml"),
        "progression": progression_loader.load_progression(root / "progression.yaml"),
        "formulas": yaml.safe_load(open(root / "formulas.yaml","r",encoding="utf-8")),
        "balance_cfg": difficulty_loader.load_difficulty(root / "difficulty.yaml"),
    }

def test_hp_mana_scale(base):
    prof_easy = dict(current_profile({"current":"easy","difficulties": base["balance_cfg"]["difficulties"]}))
    prof_hard = dict(current_profile({"current":"hard","difficulties": base["balance_cfg"]["difficulties"]}))
    hero = create_new_character("Bal", base["stats"], base["slots"], base["fields"], base["defaults"], base["resources"], progression=base["progression"], formulas=base["formulas"])
    hero.refresh_derived(base["formulas"], base["stats"], keep_percent=False, balance=prof_easy)
    hp_easy = hero.hp; mana_easy = hero.mana
    hero.refresh_derived(base["formulas"], base["stats"], keep_percent=False, balance=prof_hard)
    assert hero.hp < hp_easy
    assert hero.mana < mana_easy

def test_regen_scale(base, monkeypatch):
    prof = dict(current_profile({"current":"easy","difficulties": base["balance_cfg"]["difficulties"]}))
    hero = create_new_character("Regen", base["stats"], base["slots"], base["fields"], base["defaults"], base["resources"], progression=base["progression"], formulas=base["formulas"])
    hero.hp = 0
    now = time.time()
    # simulate a tick due; assume intervals exist
    rcfg = {"regen_intervals":{"hp":0}, "regen_amounts":{"hp":1.0}, "regen_caps":{"hp":"max"}}
    hero.regen_tick(rcfg, now, balance=prof)
    assert hero.hp >= 1.0 * prof.get("regen_amount_scale", 1.0) - 1e-6

def test_status_effect_scale(base):
    prof_harder = dict(current_profile({"current":"nightmare","difficulties": base["balance_cfg"]["difficulties"]}))
    hero = create_new_character("SE", base["stats"], base["slots"], base["fields"], base["defaults"], base["resources"], progression=base["progression"], formulas=base["formulas"])
    hero.hp = 10
    # Simulate one poison tick: baseline -1; expect larger magnitude on nightmare
    before = hero.hp
    # approximate internal call:
    hero.update_status_effects = hero.update_status_effects  # noqa (exists)
    # Fake a tiny shim: call directly similar to effect handling
    dmg = 1.0 * prof_harder.get("status_effect_scale", 1.0)
    hero.hp -= dmg
    assert hero.hp == pytest.approx(before - dmg, 1e-6)

def test_xp_gain_and_cost(base):
    prof = dict(current_profile({"current":"easy","difficulties": base["balance_cfg"]["difficulties"]}))
    hero = create_new_character("XP", base["stats"], base["slots"], base["fields"], base["defaults"], base["resources"], progression=base["progression"], formulas=base["formulas"])
    cost_easy = hero.xp_to_next_level(base["formulas"], balance=prof)
    cost_norm = hero.xp_to_next_level(base["formulas"], balance=None)
    assert cost_easy < cost_norm  # easy lowers cost via xp_cost_scale
    hero.xp_total = 0
    gained = hero.add_general_xp(200.0, base["formulas"], base["stats"], base["progression"], balance=prof)
    assert gained >= 0  # should process with gain scaling; not strict equality due to formula variability

──────────────────────────────────────────────────────────────────────────────

README & MISC
10) `README.md` — add a “Difficulty & Balance” section:
- Describe `data/difficulty.yaml`, knobs (hp_scale, mana_scale, regen_amount_scale, status_effect_scale, xp_gain_scale, xp_cost_scale).
- Mention CLI/TUI can show or select current difficulty.
- Note: changes are data-driven — no code edits required to tweak balance.
- Short examples for “easy” vs “hard”.

11) (Optional) Validators
- If you have time, add a tiny `validate_difficulty(cfg)` in `services/validate_data.py`:
  * ensure `current` is in `difficulties`
  * ensure each scale is a number > 0
- Wire it into your validator runner; otherwise skip (not required for acceptance).

──────────────────────────────────────────────────────────────────────────────

ACCEPTANCE CRITERIA
- `pre-commit run --all-files; pytest -q` passes.
- Changing `balance.current` in `difficulty.yaml` changes HP/Mana (via refresh_derived) and impacts regen/status/XP scaling when the optional `balance` arg is passed.
- CLI/TUI show a difficulty label and (optionally) allow selection before save.

CONSTRAINTS & STYLE
- Python 3.12; Black/Ruff; minimal edits; all new args optional with defaults.
- Do not break existing tests; new tests assert relative behavior, not exact numbers.

PATCH PLAN (execution order)
1) Add difficulty.yaml, loader, and balance service.  
2) Update Character methods with optional balance arg and scaling.  
3) Wire CLI runner (and wizard summary); TUI summary; scripts pass balance where meaningful.  
4) Add tests.  
5) README update.  
6) Run pre-commit + pytest; iterate until green.

FINAL COMMANDS (worldseed env)
pre-commit run --all-files; pytest -q
