### PR TITLE
Adding all of phase 4 on combat

### DIFF
--- a/combat_package/combat/data/abilities.yaml
+++ b/combat_package/combat/data/abilities.yaml
@@ -1,8 +1,29 @@
 abilities:
   - id: basic_attack
     name: "Basic Attack"
+    kind: "attack"                # future: "support", "heal", etc.
     formula: "ATT + WPN - ARM*0.6"
     damage_type: slashing
+    targeting: single_enemy       # single_enemy | self
     crit:
-      chance: "0.05 + DEX*0.002"   # ~5% + DEX scaled
+      chance: "0.05 + DEX*0.002"
       multiplier: 1.5
+    resource_cost: {}             # no cost
+    cooldown: 0
+
+  - id: fireball
+    name: "Fireball"
+    kind: "attack"
+    formula: "INT*1.2 + 6"
+    damage_type: fire
+    targeting: single_enemy
+    crit:
+      chance: "0.10 + DEX*0.002"
+      multiplier: 1.5
+    resource_cost: { mana: 5 }
+    cooldown: 2
+    on_hit:
+      apply_status:
+        - { id: burning, chance: 0.35 }
+
+# you can add more abilities later by just editing this YAML.

--- a/combat_package/combat/engine/abilities.py
+++ b/combat_package/combat/engine/abilities.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Any, List, Tuple
+from .combatant import Combatant
+from .rng import RandomSource
+from .resolution import resolve_attack
+from .effects import apply_on_hit_effects
+from ..loaders.body_parts_loader import load_body_parts
+from pathlib import Path
+
+
+@dataclass
+class AbilityUseResult:
+    ok: bool
+    reason: str = ""
+    events: List[Dict[str, Any]] = None  # list of {"type": "hit"|"miss"|"effect", ...}
+
+
+def _get_resource(c: Combatant, name: str) -> float:
+    if name == "mana":
+        return float(c.mana)
+    # room for other resources later (stamina, focus...)
+    return 0.0
+
+
+def _spend_resource(c: Combatant, name: str, amount: float) -> None:
+    if name == "mana":
+        c.mana = max(0.0, float(c.mana) - float(amount))
+    # extend when new resources appear
+
+
+def _targets_by_spec(enc_participants: List[Combatant], actor: Combatant, spec: str) -> List[str]:
+    # For now we support only "single_enemy" and "self".
+    if spec == "self":
+        return [actor.id]
+    # enemies = anyone not actor; allies are not implemented yet
+    return [c.id for c in enc_participants if c.id != actor.id and c.is_alive()]
+
+
+def can_use_ability(
+    actor: Combatant,
+    ability_def: Dict[str, Any],
+) -> Tuple[bool, str]:
+    # cooldown gate
+    cd = int(ability_def.get("cooldown", 0) or 0)
+    if cd > 0 and actor.cooldowns.get(ability_def.get("id", ""), 0) > 0:
+        return False, "on_cooldown"
+
+    # resource gate
+    costs = ability_def.get("resource_cost") or {}
+    for k, v in costs.items():
+        need = float(v)
+        have = _get_resource(actor, k)
+        if have + 1e-9 < need:
+            return False, f"insufficient_{k}"
+
+    return True, ""
+
+
+def execute_ability(
+    participants: List[Combatant],
+    actor: Combatant,
+    ability_def: Dict[str, Any],
+    target_ids: List[str],
+    rng: RandomSource,
+) -> AbilityUseResult:
+    """
+    Executes the ability (attack style only, for now).
+    Validates targets against ability.targeting.
+    Deducts resources and sets cooldown only if execution proceeds.
+    Returns events:
+      - hit/miss entries: {"type":"hit","target_id":...,"amount":...,"dtype":...,"crit":bool,"body_part":...}
+      - effect entries:   {"type":"effect","target_id":...,"effect_id":...}
+    """
+    evs: List[Dict[str, Any]] = []
+    # validate targeting
+    targeting = str(ability_def.get("targeting", "single_enemy"))
+    possible = set(_targets_by_spec(participants, actor, targeting))
+    if targeting == "single_enemy":
+        if not target_ids or target_ids[0] not in possible:
+            return AbilityUseResult(False, "invalid_target", [])
+        apply_to = [target_ids[0]]
+    elif targeting == "self":
+        apply_to = [actor.id]
+    else:
+        return AbilityUseResult(False, "unsupported_targeting", [])
+
+    # spend resources
+    ok, reason = can_use_ability(actor, ability_def)
+    if not ok:
+        return AbilityUseResult(False, reason, [])
+
+    for k, v in (ability_def.get("resource_cost") or {}).items():
+        _spend_resource(actor, k, float(v))
+
+    # set cooldown
+    cd = int(ability_def.get("cooldown", 0) or 0)
+    if cd > 0:
+        actor.cooldowns[ability_def.get("id", "")] = cd
+
+    # body parts config
+    body_cfg = load_body_parts(Path(__file__).parents[2] / "data" / "body_parts.yaml")
+
+    # execute (attack-like)
+    for tid in apply_to:
+        tgt = next((c for c in participants if c.id == tid), None)
+        if tgt is None or not tgt.is_alive():
+            continue
+        res = resolve_attack(actor, tgt, ability_def, body_cfg, rng)
+        if res.hit:
+            tgt.hp = max(0.0, tgt.hp - res.amount)
+            evs.append(
+                {
+                    "type": "hit",
+                    "target_id": tid,
+                    "amount": res.amount,
+                    "dtype": res.dtype,
+                    "crit": res.crit,
+                    "body_part": res.body_part,
+                }
+            )
+            # on-hit effects
+            for inst in apply_on_hit_effects(actor, tgt, ability_def, _load_status_cfg(), rng):
+                evs.append({"type": "effect", "target_id": tid, "effect_id": inst.id})
+        else:
+            evs.append({"type": "miss", "target_id": tid})
+    return AbilityUseResult(True, "", evs)
+
+
+def _load_status_cfg():
+    from ..loaders.status_effects_loader import load_status_effects
+    from pathlib import Path
+
+    return load_status_effects(Path(__file__).parents[2] / "data" / "status_effects.yaml")

--- a/combat_package/combat/engine/combatant.py
+++ b/combat_package/combat/engine/combatant.py
@@ -13,6 +13,7 @@ class Combatant:
     resist: Dict[str, float] = field(default_factory=dict)
     tags: List[str] = field(default_factory=list)  # e.g., ["humanoid"]
     statuses: List[dict] = field(default_factory=list)  # runtime status instances
+    cooldowns: Dict[str, int] = field(default_factory=dict)  # ability_id -> remaining turns
 
     def is_alive(self) -> bool:
         return self.hp > 0

--- a/combat_package/combat/engine/encounter.py
+++ b/combat_package/combat/engine/encounter.py
@@ -42,6 +42,15 @@ class Encounter:
         self._ptr = (self._ptr + 1) % len(self._order)
         return self.participants[idx]
 
+    def tick_cooldowns(self, actor: Combatant) -> None:
+        if not actor.cooldowns:
+            return
+        for k in list(actor.cooldowns.keys()):
+            actor.cooldowns[k] = max(0, int(actor.cooldowns.get(k, 0)) - 1)
+            if actor.cooldowns[k] == 0:
+                # keep key with 0 so UI can show ready state; or remove if preferred
+                pass
+
     def run_round(self) -> dict:
         """
         Very small demo round:

--- a/combat_package/scripts/run_battle_cli.py
+++ b/combat_package/scripts/run_battle_cli.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 from pathlib import Path
 from combat.engine.combatant import Combatant
 from combat.engine.encounter import Encounter
-from combat.engine.resolution import resolve_attack
-from combat.engine.effects import apply_on_hit_effects, tick_start_of_turn
+from combat.engine.abilities import execute_ability, can_use_ability
+from combat.engine.effects import tick_start_of_turn
 from combat.engine.narration import render_event, render_status_apply, render_dot_tick
 from combat.loaders.abilities_loader import load_abilities
-from combat.loaders.status_effects_loader import load_status_effects
 from combat.loaders.narration_loader import load_narration
+from combat.loaders.status_effects_loader import load_status_effects
 
 
 def main():
@@ -15,8 +15,8 @@ def main():
         id="A",
         name="Aria the Fighter",
         stats={"ATT": 8, "DEX": 7, "ARM": 3, "WPN": 3},
-        hp=30.0,
-        mana=10.0,
+        hp=32.0,
+        mana=6.0,
         resist={},
         tags=["humanoid"],
     )
@@ -24,127 +24,107 @@ def main():
         id="B",
         name="Belor the Wizard",
         stats={"ATT": 6, "DEX": 8, "INT": 12, "ARM": 2, "WPN": 1},
-        hp=26.0,
-        mana=18.0,
+        hp=28.0,
+        mana=12.0,
         resist={"fire": 0.10},
         tags=["humanoid"],
     )
 
-    enc = Encounter([a, b], seed=1337)
+    enc = Encounter([a, b], seed=777)
     data_root = Path(__file__).parents[1] / "combat" / "data"
     abilities = load_abilities(data_root / "abilities.yaml")
-    status_cfg = load_status_effects(data_root / "status_effects.yaml")
     narr = load_narration(data_root / "narration.yaml")
+    status_cfg = load_status_effects(data_root / "status_effects.yaml")
 
-    # Add a simple fireball ability on the fly if not present
-    fireball = next(
-        (x for x in abilities.get("abilities", []) if x.get("id") == "fireball"), None
-    )
-    if not fireball:
-        fireball = {
-            "id": "fireball",
-            "name": "Fireball",
-            "formula": "INT*1.2 + 6",
-            "damage_type": "fire",
-            "crit": {"chance": "0.10 + DEX*0.002", "multiplier": 1.5},
-            "on_hit": {"apply_status": [{"id": "burning", "chance": 1.0}]},
-        }
-        abilities.setdefault("abilities", []).append(fireball)
-    basic = next(
-        (x for x in abilities.get("abilities", []) if x.get("id") == "basic_attack"),
-        None,
-    )
-    if not basic:
-        basic = {
-            "id": "basic_attack",
-            "name": "Basic Attack",
-            "formula": "ATT + WPN - ARM*0.6",
-            "damage_type": "slashing",
-            "crit": {"chance": "0.05 + DEX*0.002", "multiplier": 1.5},
-        }
-        abilities["abilities"].append(basic)
+    # helpers
+    def ability_by_id(aid: str):
+        return next((x for x in abilities.get("abilities", []) if x.get("id") == aid), None)
+
+    basic = ability_by_id("basic_attack")
+    fireball = ability_by_id("fireball")
 
     for round_idx in range(1, 6):
         print(f"\n-- Round {round_idx} --")
-        # start-of-turn ticks (A then B)
-        for actor in [a, b]:
-            evs = tick_start_of_turn(actor, status_cfg, enc.rng)
-            for ev in evs:
+
+        # Start-of-turn: A ticks cooldowns + statuses
+        enc.tick_cooldowns(a)
+        for ev in tick_start_of_turn(a, status_cfg, enc.rng):
+            print(
+                "•",
+                render_dot_tick(a.name, ev["effect_id"], ev["amount"], status_cfg, narr, enc.rng),
+            )
+        # A tries to use fireball if enough mana, else basic
+        use_fire = can_use_ability(a, fireball)[0] if fireball else False
+        ab = fireball if use_fire else basic
+        res = execute_ability(enc.participants, a, ab, [b.id], enc.rng)
+        for ev in res.events or []:
+            if ev["type"] == "hit" or ev["type"] == "miss":
                 print(
                     "•",
-                    render_dot_tick(
-                        actor.name,
-                        ev["effect_id"],
-                        ev["amount"],
-                        status_cfg,
+                    render_event(
+                        {
+                            "actor": a.name,
+                            "target": b.name,
+                            "hit": ev["type"] == "hit",
+                            "crit": ev.get("crit", False),
+                            "amount": ev.get("amount", 0.0),
+                            "dtype": ev.get("dtype", "slashing"),
+                            "body_part": ev.get("body_part", "chest"),
+                        },
                         narr,
                         enc.rng,
                     ),
                 )
-
-        # A uses basic attack on B
-        r1 = resolve_attack(
-            a,
-            b,
-            basic,
-            {"groups": {"humanoid": ["chest", "arm", "leg"]}, "weights": {}},
-            enc.rng,
-        )
-        print(
-            "•",
-            render_event(
-                {
-                    "actor": a.name,
-                    "target": b.name,
-                    "hit": r1.hit,
-                    "crit": r1.crit,
-                    "amount": r1.amount,
-                    "dtype": r1.dtype,
-                    "body_part": r1.body_part,
-                },
-                narr,
-                enc.rng,
-            ),
-        )
-        if r1.hit:
-            b.hp = max(0.0, b.hp - r1.amount)
-
-        # B uses fireball on A (apply burning)
-        r2 = resolve_attack(
-            b,
-            a,
-            fireball,
-            {"groups": {"humanoid": ["chest", "arm", "leg"]}, "weights": {}},
-            enc.rng,
-        )
-        print(
-            "•",
-            render_event(
-                {
-                    "actor": b.name,
-                    "target": a.name,
-                    "hit": r2.hit,
-                    "crit": r2.crit,
-                    "amount": r2.amount,
-                    "dtype": r2.dtype,
-                    "body_part": r2.body_part,
-                },
-                narr,
-                enc.rng,
-            ),
-        )
-        if r2.hit:
-            a.hp = max(0.0, a.hp - r2.amount)
-            insts = apply_on_hit_effects(b, a, fireball, status_cfg, enc.rng)
-            for inst in insts:
+            elif ev["type"] == "effect":
                 print(
-                    "•", render_status_apply(a.name, inst.id, status_cfg, narr, enc.rng)
+                    "•",
+                    render_status_apply(b.name, ev["effect_id"], status_cfg, narr, enc.rng),
                 )
 
-        if a.hp <= 0 or b.hp <= 0:
+        if not b.is_alive():
             break
 
-    print(f"\nFinal HP → {a.name}: {a.hp} | {b.name}: {b.hp}")
+        # Start-of-turn: B ticks cooldowns + statuses
+        enc.tick_cooldowns(b)
+        for ev in tick_start_of_turn(b, status_cfg, enc.rng):
+            print(
+                "•",
+                render_dot_tick(b.name, ev["effect_id"], ev["amount"], status_cfg, narr, enc.rng),
+            )
+        # B always uses fireball if possible else basic
+        use_fire_b = can_use_ability(b, fireball)[0] if fireball else False
+        ab_b = fireball if use_fire_b else basic
+        res_b = execute_ability(enc.participants, b, ab_b, [a.id], enc.rng)
+        for ev in res_b.events or []:
+            if ev["type"] == "hit" or ev["type"] == "miss":
+                print(
+                    "•",
+                    render_event(
+                        {
+                            "actor": b.name,
+                            "target": a.name,
+                            "hit": ev["type"] == "hit",
+                            "crit": ev.get("crit", False),
+                            "amount": ev.get("amount", 0.0),
+                            "dtype": ev.get("dtype", "slashing"),
+                            "body_part": ev.get("body_part", "chest"),
+                        },
+                        narr,
+                        enc.rng,
+                    ),
+                )
+            elif ev["type"] == "effect":
+                print(
+                    "•",
+                    render_status_apply(a.name, ev["effect_id"], status_cfg, narr, enc.rng),
+                )
+
+        if not a.is_alive():
+            break
+
+    print(
+        f"\nFinal → {a.name}: HP {a.hp:.1f}, Mana {a.mana:.1f} | {b.name}: HP {b.hp:.1f}, Mana {b.mana:.1f}"
+    )
 
 
 if __name__ == "__main__":

--- a/combat_package/tests/test_abilities_core.py
+++ b/combat_package/tests/test_abilities_core.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+from pathlib import Path
+from combat.engine.combatant import Combatant
+from combat.engine.abilities import can_use_ability, execute_ability
+from combat.engine.rng import RandomSource
+from combat.loaders.abilities_loader import load_abilities
+
+
+def _load_abilities():
+    return load_abilities(Path(__file__).parents[1] / "combat" / "data" / "abilities.yaml")
+
+
+def _ability(abilities, aid: str):
+    return next((x for x in abilities.get("abilities", []) if x.get("id") == aid), None)
+
+
+def test_resource_cost_and_cooldown_applied():
+    abilities = _load_abilities()
+    fireball = _ability(abilities, "fireball")
+    a = Combatant(
+        "A",
+        "Caster",
+        {"INT": 12, "DEX": 8},
+        hp=20.0,
+        mana=6.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    b = Combatant(
+        "B",
+        "Target",
+        {"DEX": 1, "ARM": 0},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    ok, reason = can_use_ability(a, fireball)
+    assert ok
+    res = execute_ability([a, b], a, fireball, [b.id], RandomSource(9))
+    assert res.ok
+    # mana spent and cooldown set
+    assert a.mana < 6.0
+    assert a.cooldowns.get("fireball", 0) >= 1
+
+
+def test_insufficient_mana_prevents_cast():
+    abilities = _load_abilities()
+    fireball = _ability(abilities, "fireball")
+    a = Combatant(
+        "A",
+        "Caster",
+        {"INT": 12, "DEX": 8},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    ok, reason = can_use_ability(a, fireball)
+    assert not ok and "insufficient_mana" in reason
+
+
+def test_invalid_target_rejected():
+    abilities = _load_abilities()
+    fireball = _ability(abilities, "fireball")
+    a = Combatant(
+        "A",
+        "Caster",
+        {"INT": 12, "DEX": 8},
+        hp=20.0,
+        mana=10.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    b = Combatant(
+        "B",
+        "Target",
+        {"DEX": 1, "ARM": 0},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    res = execute_ability([a, b], a, fireball, ["Z"], RandomSource(1))
+    assert not res.ok and res.reason == "invalid_target"
+
+
+def test_cooldown_ticks_down():
+    abilities = _load_abilities()
+    fireball = _ability(abilities, "fireball")
+    a = Combatant(
+        "A",
+        "Caster",
+        {"INT": 12, "DEX": 8},
+        hp=20.0,
+        mana=20.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    b = Combatant(
+        "B",
+        "Target",
+        {"DEX": 1, "ARM": 0},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid"],
+    )
+    # first cast ok
+    res1 = execute_ability([a, b], a, fireball, [b.id], RandomSource(2))
+    assert res1.ok
+    # immediate second cast blocked due to cooldown
+    ok2, reason2 = can_use_ability(a, fireball)
+    assert not ok2 and reason2 == "on_cooldown"
+    # tick cooldown twice → ready
+    from combat.engine.encounter import Encounter
+
+    enc = Encounter([a, b], seed=3)
+    enc.tick_cooldowns(a)
+    enc.tick_cooldowns(a)
+    ok3, _ = can_use_ability(a, fireball)
+    assert ok3

--- a/combat_package/worldseed_combat.egg-info/SOURCES.txt
+++ b/combat_package/worldseed_combat.egg-info/SOURCES.txt
@@ -2,6 +2,7 @@ README.md
 pyproject.toml
 combat/__init__.py
 combat/engine/__init__.py
+combat/engine/abilities.py
 combat/engine/actions.py
 combat/engine/combatant.py
 combat/engine/effects.py
@@ -15,6 +16,7 @@ combat/loaders/body_parts_loader.py
 combat/loaders/damage_types_loader.py
 combat/loaders/narration_loader.py
 combat/loaders/status_effects_loader.py
+tests/test_abilities_core.py
 tests/test_damage_math.py
 tests/test_effects_burning.py
 tests/test_effects_stack.py


### PR DESCRIPTION
Update for patch 4 for combat which includes: 

# combat_update_4 — Abilities layer (costs, targeting, cooldowns) + tests + CLI demo

ENV
- Use the worldseed interpreter (.venv), not “base”.

GOAL
Introduce a clean, modular abilities pipeline to the standalone combat engine:
- Ability definitions in YAML (costs, cooldown, targeting).
- Validation at use-time: resources + cooldown + valid targets.
- Execution: calls existing attack resolution + on-hit effects.
- Cooldown ticking at actor turn start.
- No XP logic. UI-agnostic.

SCOPE
Create/modify exactly these:
- YAML: update abilities.yaml (add fireball with costs/targeting/cooldown).
- NEW engine module: abilities.py (ability checks + execution).
- Extend engine: combatant.py (cooldowns map), encounter.py (turn tick helper).
- CLI demo: exercise fireball cost/cooldown.
- Tests: costs, cooldowns, targeting, insufficient resources.

──────────────────────────────────────────────────────────────────────────────
DATA — overwrite abilities.yaml to include cost/targeting/cooldown

# combat_package/combat/data/abilities.yaml
abilities:
  - id: basic_attack
    name: "Basic Attack"
    kind: "attack"                # future: "support", "heal", etc.
    formula: "ATT + WPN - ARM*0.6"
    damage_type: slashing
    targeting: single_enemy       # single_enemy | self
    crit:
      chance: "0.05 + DEX*0.002"
      multiplier: 1.5
    resource_cost: {}             # no cost
    cooldown: 0

  - id: fireball
    name: "Fireball"
    kind: "attack"
    formula: "INT*1.2 + 6"
    damage_type: fire
    targeting: single_enemy
    crit:
      chance: "0.10 + DEX*0.002"
      multiplier: 1.5
    resource_cost: { mana: 5 }
    cooldown: 2
    on_hit:
      apply_status:
        - { id: burning, chance: 0.35 }

# you can add more abilities later by just editing this YAML.
──────────────────────────────────────────────────────────────────────────────
ENGINE — new abilities module

# NEW: combat_package/combat/engine/abilities.py
from __future__ import annotations
from dataclasses import dataclass
from typing import Dict, Any, List, Tuple
from .combatant import Combatant
from .rng import RandomSource
from .resolution import resolve_attack
from .effects import apply_on_hit_effects
from ..loaders.body_parts_loader import load_body_parts
from pathlib import Path

@dataclass
class AbilityUseResult:
    ok: bool
    reason: str = ""
    events: List[Dict[str, Any]] = None  # list of {"type": "hit"|"miss"|"effect", ...}

def _get_resource(c: Combatant, name: str) -> float:
    if name == "mana":
        return float(c.mana)
    # room for other resources later (stamina, focus...)
    return 0.0

def _spend_resource(c: Combatant, name: str, amount: float) -> None:
    if name == "mana":
        c.mana = max(0.0, float(c.mana) - float(amount))
    # extend when new resources appear

def _targets_by_spec(enc_participants: List[Combatant], actor: Combatant, spec: str) -> List[str]:
    # For now we support only "single_enemy" and "self".
    if spec == "self":
        return [actor.id]
    # enemies = anyone not actor; allies are not implemented yet
    return [c.id for c in enc_participants if c.id != actor.id and c.is_alive()]

def can_use_ability(
    actor: Combatant,
    ability_def: Dict[str, Any],
) -> Tuple[bool, str]:
    # cooldown gate
    cd = int(ability_def.get("cooldown", 0) or 0)
    if cd > 0 and actor.cooldowns.get(ability_def.get("id",""), 0) > 0:
        return False, "on_cooldown"

    # resource gate
    costs = ability_def.get("resource_cost") or {}
    for k, v in costs.items():
        need = float(v)
        have = _get_resource(actor, k)
        if have + 1e-9 < need:
            return False, f"insufficient_{k}"

    return True, ""

def execute_ability(
    participants: List[Combatant],
    actor: Combatant,
    ability_def: Dict[str, Any],
    target_ids: List[str],
    rng: RandomSource,
) -> AbilityUseResult:
    """
    Executes the ability (attack style only, for now).
    Validates targets against ability.targeting.
    Deducts resources and sets cooldown only if execution proceeds.
    Returns events:
      - hit/miss entries: {"type":"hit","target_id":...,"amount":...,"dtype":...,"crit":bool,"body_part":...}
      - effect entries:   {"type":"effect","target_id":...,"effect_id":...}
    """
    evs: List[Dict[str, Any]] = []
    # validate targeting
    targeting = str(ability_def.get("targeting", "single_enemy"))
    possible = set(_targets_by_spec(participants, actor, targeting))
    if targeting == "single_enemy":
        if not target_ids or target_ids[0] not in possible:
            return AbilityUseResult(False, "invalid_target", [])
        apply_to = [target_ids[0]]
    elif targeting == "self":
        apply_to = [actor.id]
    else:
        return AbilityUseResult(False, "unsupported_targeting", [])

    # spend resources
    ok, reason = can_use_ability(actor, ability_def)
    if not ok:
        return AbilityUseResult(False, reason, [])

    for k, v in (ability_def.get("resource_cost") or {}).items():
        _spend_resource(actor, k, float(v))

    # set cooldown
    cd = int(ability_def.get("cooldown", 0) or 0)
    if cd > 0:
        actor.cooldowns[ability_def.get("id","")] = cd

    # body parts config
    body_cfg = load_body_parts(Path(__file__).parents[2] / "data" / "body_parts.yaml")

    # execute (attack-like)
    for tid in apply_to:
        tgt = next((c for c in participants if c.id == tid), None)
        if tgt is None or not tgt.is_alive():
            continue
        res = resolve_attack(actor, tgt, ability_def, body_cfg, rng)
        if res.hit:
            tgt.hp = max(0.0, tgt.hp - res.amount)
            evs.append({"type":"hit","target_id":tid,"amount":res.amount,"dtype":res.dtype,"crit":res.crit,"body_part":res.body_part})
            # on-hit effects
            for inst in apply_on_hit_effects(actor, tgt, ability_def, _load_status_cfg(), rng):
                evs.append({"type":"effect","target_id":tid,"effect_id":inst.id})
        else:
            evs.append({"type":"miss","target_id":tid})
    return AbilityUseResult(True, "", evs)

def _load_status_cfg():
    from ..loaders.status_effects_loader import load_status_effects
    from pathlib import Path
    return load_status_effects(Path(__file__).parents[2] / "data" / "status_effects.yaml")
──────────────────────────────────────────────────────────────────────────────
ENGINE — extend combatant + encounter

# PATCH: combat_package/combat/engine/combatant.py
# Add cooldowns mapping (runtime, not saved by engine).
from dataclasses import dataclass, field
from typing import Dict, List

@dataclass
class Combatant:
    id: str
    name: str
    stats: Dict[str, float]
    hp: float
    mana: float
    resist: Dict[str, float] = field(default_factory=dict)
    tags: List[str] = field(default_factory=list)
    statuses: List[dict] = field(default_factory=list)
    cooldowns: Dict[str, int] = field(default_factory=dict)  # ability_id -> remaining turns
    def is_alive(self) -> bool:
        return self.hp > 0

# PATCH: combat_package/combat/engine/encounter.py
# Add a helper to tick cooldowns at the start of an actor's turn (non-breaking).
    def tick_cooldowns(self, actor: Combatant) -> None:
        if not actor.cooldowns:
            return
        for k in list(actor.cooldowns.keys()):
            actor.cooldowns[k] = max(0, int(actor.cooldowns.get(k, 0)) - 1)
            if actor.cooldowns[k] == 0:
                # keep key with 0 so UI can show ready state; or remove if preferred
                pass
──────────────────────────────────────────────────────────────────────────────
CLI DEMO — use fireball with cost/cooldown

# OVERWRITE: combat_package/scripts/run_battle_cli.py
from __future__ import annotations
from pathlib import Path
from combat.engine.combatant import Combatant
from combat.engine.encounter import Encounter
from combat.engine.abilities import execute_ability, can_use_ability
from combat.engine.effects import tick_start_of_turn
from combat.engine.narration import render_event, render_status_apply, render_dot_tick
from combat.loaders.abilities_loader import load_abilities
from combat.loaders.narration_loader import load_narration
from combat.loaders.body_parts_loader import load_body_parts
from combat.loaders.status_effects_loader import load_status_effects

def main():
    a = Combatant(id="A", name="Aria the Fighter",
                  stats={"ATT":8,"DEX":7,"ARM":3,"WPN":3}, hp=32.0, mana=6.0, resist={}, tags=["humanoid"])
    b = Combatant(id="B", name="Belor the Wizard",
                  stats={"ATT":6,"DEX":8,"INT":12,"ARM":2,"WPN":1}, hp=28.0, mana=12.0, resist={"fire":0.10}, tags=["humanoid"])

    enc = Encounter([a, b], seed=777)
    data_root = Path(__file__).parents[1] / "combat" / "data"
    abilities = load_abilities(data_root / "abilities.yaml")
    narr = load_narration(data_root / "narration.yaml")
    parts = load_body_parts(data_root / "body_parts.yaml")
    status_cfg = load_status_effects(data_root / "status_effects.yaml")

    # helpers
    def ability_by_id(aid: str):
        return next((x for x in abilities.get("abilities", []) if x.get("id")==aid), None)

    basic = ability_by_id("basic_attack")
    fireball = ability_by_id("fireball")

    for round_idx in range(1, 6):
        print(f"\n-- Round {round_idx} --")

        # Start-of-turn: A ticks cooldowns + statuses
        enc.tick_cooldowns(a)
        for ev in tick_start_of_turn(a, status_cfg, enc.rng):
            print("•", render_dot_tick(a.name, ev["effect_id"], ev["amount"], status_cfg, narr, enc.rng))
        # A tries to use fireball if enough mana, else basic
        use_fire = can_use_ability(a, fireball)[0] if fireball else False
        ab = fireball if use_fire else basic
        res = execute_ability(enc.participants, a, ab, [b.id], enc.rng)
        for ev in res.events or []:
            if ev["type"]=="hit" or ev["type"]=="miss":
                print("•", render_event({"actor": a.name, "target": b.name, "hit": ev["type"]=="hit", "crit": ev.get("crit", False), "amount": ev.get("amount", 0.0), "dtype": ev.get("dtype","slashing"), "body_part": ev.get("body_part","chest")}, narr, enc.rng))
            elif ev["type"]=="effect":
                print("•", render_status_apply(b.name, ev["effect_id"], status_cfg, narr, enc.rng))

        if not b.is_alive(): break

        # Start-of-turn: B ticks cooldowns + statuses
        enc.tick_cooldowns(b)
        for ev in tick_start_of_turn(b, status_cfg, enc.rng):
            print("•", render_dot_tick(b.name, ev["effect_id"], ev["amount"], status_cfg, narr, enc.rng))
        # B always uses fireball if possible else basic
        use_fire_b = can_use_ability(b, fireball)[0] if fireball else False
        ab_b = fireball if use_fire_b else basic
        res_b = execute_ability(enc.participants, b, ab_b, [a.id], enc.rng)
        for ev in res_b.events or []:
            if ev["type"]=="hit" or ev["type"]=="miss":
                print("•", render_event({"actor": b.name, "target": a.name, "hit": ev["type"]=="hit", "crit": ev.get("crit", False), "amount": ev.get("amount", 0.0), "dtype": ev.get("dtype","slashing"), "body_part": ev.get("body_part","chest")}, narr, enc.rng))
            elif ev["type"]=="effect":
                print("•", render_status_apply(a.name, ev["effect_id"], status_cfg, narr, enc.rng))

        if not a.is_alive(): break

    print(f"\nFinal → {a.name}: HP {a.hp:.1f}, Mana {a.mana:.1f} | {b.name}: HP {b.hp:.1f}, Mana {b.mana:.1f}")

if __name__ == "__main__":
    main()
──────────────────────────────────────────────────────────────────────────────
TESTS — new tests for costs, cooldowns, targeting

# combat_package/tests/test_abilities_core.py
from __future__ import annotations
from pathlib import Path
from combat.engine.combatant import Combatant
from combat.engine.abilities import can_use_ability, execute_ability
from combat.engine.rng import RandomSource
from combat.loaders.abilities_loader import load_abilities

def _load_abilities():
    return load_abilities(Path(__file__).parents[1] / "combat" / "data" / "abilities.yaml")

def _ability(abilities, aid: str):
    return next((x for x in abilities.get("abilities", []) if x.get("id")==aid), None)

def test_resource_cost_and_cooldown_applied():
    abilities = _load_abilities()
    fireball = _ability(abilities, "fireball")
    a = Combatant("A","Caster",{"INT":12,"DEX":8}, hp=20.0, mana=6.0, resist={}, tags=["humanoid"])
    b = Combatant("B","Target",{"DEX":1,"ARM":0}, hp=20.0, mana=0.0, resist={}, tags=["humanoid"])
    ok, reason = can_use_ability(a, fireball)
    assert ok
    res = execute_ability([a,b], a, fireball, [b.id], RandomSource(9))
    assert res.ok
    # mana spent and cooldown set
    assert a.mana < 6.0
    assert a.cooldowns.get("fireball", 0) >= 1

def test_insufficient_mana_prevents_cast():
    abilities = _load_abilities()
    fireball = _ability(abilities, "fireball")
    a = Combatant("A","Caster",{"INT":12,"DEX":8}, hp=20.0, mana=0.0, resist={}, tags=["humanoid"])
    b = Combatant("B","Target",{"DEX":1,"ARM":0}, hp=20.0, mana=0.0, resist={}, tags=["humanoid"])
    ok, reason = can_use_ability(a, fireball)
    assert not ok and "insufficient_mana" in reason

def test_invalid_target_rejected():
    abilities = _load_abilities()
    fireball = _ability(abilities, "fireball")
    a = Combatant("A","Caster",{"INT":12,"DEX":8}, hp=20.0, mana=10.0, resist={}, tags=["humanoid"])
    b = Combatant("B","Target",{"DEX":1,"ARM":0}, hp=20.0, mana=0.0, resist={}, tags=["humanoid"])
    res = execute_ability([a,b], a, fireball, ["Z"], RandomSource(1))
    assert not res.ok and res.reason == "invalid_target"

def test_cooldown_ticks_down():
    abilities = _load_abilities()
    fireball = _ability(abilities, "fireball")
    a = Combatant("A","Caster",{"INT":12,"DEX":8}, hp=20.0, mana=20.0, resist={}, tags=["humanoid"])
    b = Combatant("B","Target",{"DEX":1,"ARM":0}, hp=20.0, mana=0.0, resist={}, tags=["humanoid"])
    # first cast ok
    res1 = execute_ability([a,b], a, fireball, [b.id], RandomSource(2))
    assert res1.ok
    # immediate second cast blocked due to cooldown
    ok2, reason2 = can_use_ability(a, fireball)
    assert not ok2 and reason2 == "on_cooldown"
    # tick cooldown twice → ready
    from combat.engine.encounter import Encounter
    enc = Encounter([a,b], seed=3)
    enc.tick_cooldowns(a); enc.tick_cooldowns(a)
    ok3, _ = can_use_ability(a, fireball)
    assert ok3
──────────────────────────────────────────────────────────────────────────────
ACCEPTANCE (from combat_package/)

Windows:
  .\.venv\Scripts\Activate.ps1; pip install -e ".[dev]"; pre-commit run --all-files; pytest -q; python scripts/run_battle_cli.py

macOS/Linux:
  source .venv/bin/activate && pip install -e ".[dev]" && pre-commit run --all-files && pytest -q && python scripts/run_battle_cli.py

EXPECTED
- All tests pass (existing ones + new abilities tests).
- CLI shows fireball consuming mana and going on cooldown; basic attack used when fireball unavailable.
- No XP logic added. No UI dependencies. Behavior fully data-driven.

CONSTRAINTS
- Keep public API surface stable (do not break earlier tests).
- Only read YAML from combat/data; tolerate missing keys with defaults.
- Keep abilities generic: engine doesn’t “know” about stories/classes.
