### PR TITLE
Feature/combat branch 9

### DIFF
--- a/combat_package/combat/data/hazards.yaml
+++ b/combat_package/combat/data/hazards.yaml
@@ -1,0 +1,35 @@
+hazards:
+  - id: lava_zone
+    name: "Lava Flow"
+    phase: start_of_turn             # start_of_round | start_of_turn | end_of_turn
+    targeting:
+      locations: ["lava"]            # affect only units whose combatant.location in this set
+      require_tag_absent: ["flying"] # skip targets with any of these tags
+      team: any                      # any | alpha | beta (string match to combatant.team)
+    duration_rounds: 0               # 0 = persistent
+    effects:
+      damage:
+        amount: "4 + INT*0.0"
+        damage_type: fire
+      apply_status:
+        - { id: burning, chance: 0.25 }
+    narration:
+      tick:
+        - { text: "Lava spits at {target}, searing for {amount}.", weight: 2 }
+        - { text: "{target} skirts molten stone ({amount}).", weight: 1 }
+
+  - id: healing_fountain
+    name: "Fountain of Renewal"
+    phase: end_of_turn
+    targeting:
+      locations: ["fountain"]
+      team: any
+    duration_rounds: 0
+    effects:
+      heal:
+        amount: 3
+      resource:
+        mana: 1
+    narration:
+      tick:
+        - { text: "Cool waters mend {target} for {amount}.", weight: 2 }

--- a/combat_package/combat/engine/combatant.py
+++ b/combat_package/combat/engine/combatant.py
@@ -18,6 +18,7 @@ class Combatant:
     cooldowns: Dict[str, int] = field(default_factory=dict)  # ability_id -> remaining turns
     team: str = "neutral"  # NEW: team label for targeting logic
     inventory: Dict[str, int] = field(default_factory=dict)  # NEW: item_id -> count
+    location: str = "arena"  # NEW: simple location label (for hazards/terrain)
 
     def is_alive(self) -> bool:
         return self.hp > 0

--- a/combat_package/combat/engine/environment.py
+++ b/combat_package/combat/engine/environment.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+from .combatant import Combatant
+from .rng import RandomSource
+import ast
+
+
+def _safe_eval(expr: str, ctx: Dict[str, float]) -> float:
+    if not isinstance(expr, str):
+        return float(expr)
+    tree = ast.parse(expr, mode="eval")
+    SAFE = (
+        ast.Expression,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Constant,
+        ast.Name,
+        ast.Load,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.UAdd,
+        ast.USub,
+    )
+
+    def ev(n):
+        if type(n) not in SAFE:
+            raise ValueError("Unsafe")
+        if isinstance(n, ast.Expression):
+            return ev(n.body)
+        if isinstance(n, ast.Constant):
+            if isinstance(n.value, (int, float)):
+                return float(n.value)
+            raise ValueError("bad const")
+        if isinstance(n, ast.Name):
+            return float(ctx.get(n.id, 0.0))
+        if isinstance(n, ast.UnaryOp):
+            v = ev(n.operand)
+            return +v if isinstance(n.op, ast.UAdd) else -v
+        if isinstance(n, ast.BinOp):
+            a, b = ev(n.left), ev(n.right)
+            if isinstance(n.op, ast.Add):
+                return a + b
+            if isinstance(n.op, ast.Sub):
+                return a - b
+            if isinstance(n.op, ast.Mult):
+                return a * b
+            if isinstance(n.op, ast.Div):
+                return a / b if b != 0 else 0.0
+        raise ValueError("Unsupported")
+
+    return float(ev(tree))
+
+
+def _choice_weighted(rng: RandomSource, lines: List[dict]) -> str:
+    if not lines:
+        return ""
+    pool = []
+    for ln in lines:
+        w = int(ln.get("weight", 1) or 1)
+        pool.extend([ln.get("text", "")] * max(1, w))
+    return rng.choice(pool)
+
+
+class Environment:
+    """
+    Applies hazard effects at configured phases.
+    Keeps per-hazard remaining duration (rounds) if > 0.
+    """
+
+    def __init__(self, hazards_cfg: Dict[str, Any]):
+        self.hazards = []
+        for h in hazards_cfg.get("hazards") or []:
+            h = dict(h)
+            dur = int(h.get("duration_rounds", 0) or 0)
+            h["_remaining_rounds"] = dur
+            self.hazards.append(h)
+
+    def tick_round_boundary(self) -> None:
+        """Call at start_of_round to decrement round-based durations AFTER the first round."""
+        # We'll decrement at the *end* of a full round in Encounter; for simplicity, leave here no-op.
+        pass
+
+    def process_phase(
+        self,
+        phase: str,
+        participants: List[Combatant],
+        rng: RandomSource,
+    ) -> List[Dict[str, Any]]:
+        """
+        Returns a list of typed events for narration/logging:
+          {"type":"hazard","hazard_id":..., "target_id":..., "kind":"damage|heal|resource|effect", "amount":float, "dtype":str|None}
+        """
+        events: List[Dict[str, Any]] = []
+        for hz in list(self.hazards):
+            if hz.get("phase") != phase:
+                continue
+            # duration check: 0 = persistent; if >0 and exhausted, skip
+            if int(hz.get("_remaining_rounds", 0)) == 0 and int(hz.get("duration_rounds", 0)) > 0:
+                continue
+            t = hz.get("targeting") or {}
+            locs = set(t.get("locations") or [])
+            team = str(t.get("team", "any"))
+            absent = set(t.get("require_tag_absent") or [])
+            # candidates
+            cands = [c for c in participants if c.is_alive()]
+            if locs:
+                cands = [c for c in cands if c.location in locs]
+            if team != "any":
+                cands = [c for c in cands if c.team == team]
+            if absent:
+                cands = [c for c in cands if not any(tag in absent for tag in (c.tags or []))]
+
+            eff = hz.get("effects") or {}
+            for c in cands:
+                # context: victim stats for scaling (safe)
+                ctx = {
+                    "STR": float(c.stats.get("STR", 0.0)),
+                    "DEX": float(c.stats.get("DEX", 0.0)),
+                    "INT": float(c.stats.get("INT", 0.0)),
+                    "STA": float(c.stats.get("STA", 0.0)),
+                }
+                # damage
+                if "damage" in eff:
+                    spec = eff["damage"] or {}
+                    amt = spec.get("amount", 0)
+                    try:
+                        val = max(0.0, _safe_eval(amt, ctx))
+                    except Exception:
+                        val = 0.0
+                    dtype = spec.get("damage_type")
+                    # apply resist
+                    res = float(c.resist.get(dtype, 0.0)) if dtype else 0.0
+                    val = round(val * (1.0 - max(0.0, min(1.0, res))), 1)
+                    if val > 0:
+                        c.hp = max(0.0, c.hp - val)
+                        events.append(
+                            {
+                                "type": "hazard",
+                                "hazard_id": hz.get("id"),
+                                "target_id": c.id,
+                                "kind": "damage",
+                                "amount": val,
+                                "dtype": dtype,
+                            }
+                        )
+                # heal
+                if "heal" in eff:
+                    h = float(eff["heal"].get("amount", 0))
+                    if h > 0:
+                        c.hp = c.hp + h
+                        events.append(
+                            {
+                                "type": "hazard",
+                                "hazard_id": hz.get("id"),
+                                "target_id": c.id,
+                                "kind": "heal",
+                                "amount": h,
+                                "dtype": None,
+                            }
+                        )
+                # resource (mana only for now)
+                if "resource" in eff:
+                    mp = float((eff["resource"] or {}).get("mana", 0))
+                    if mp > 0:
+                        c.mana = c.mana + mp
+                        events.append(
+                            {
+                                "type": "hazard",
+                                "hazard_id": hz.get("id"),
+                                "target_id": c.id,
+                                "kind": "resource",
+                                "amount": mp,
+                                "dtype": None,
+                            }
+                        )
+                # apply_status
+                for spec in eff.get("apply_status") or []:
+                    from .effects import apply_status
+
+                    eid = spec.get("id")
+                    chance = float(spec.get("chance", 1.0))
+                    if eid and rng.randf() <= chance:
+                        inst = apply_status(
+                            c, eid, {"effects": {}}, source_id=f"hazard:{hz.get('id')}"
+                        )
+                        if inst:
+                            events.append(
+                                {
+                                    "type": "hazard",
+                                    "hazard_id": hz.get("id"),
+                                    "target_id": c.id,
+                                    "kind": "effect",
+                                    "effect_id": eid,
+                                    "amount": 0.0,
+                                    "dtype": None,
+                                }
+                            )
+            # duration bookkeeping for finite hazards: decrement per round at end_of_turn of last unit if needed (handled by Encounter)
+        return events

--- a/combat_package/combat/loaders/hazards_loader.py
+++ b/combat_package/combat/loaders/hazards_loader.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from pathlib import Path
+import yaml
+
+
+def load_hazards(path: str | Path) -> dict:
+    p = Path(path)
+    if not p.exists():
+        return {"hazards": []}
+    with open(p, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    data.setdefault("hazards", [])
+    return data

--- a/combat_package/scripts/run_battle_cli.py
+++ b/combat_package/scripts/run_battle_cli.py
@@ -3,24 +3,35 @@ from pathlib import Path
 from combat.engine.combatant import Combatant
 from combat.engine.encounter import Encounter
 from combat.engine.ai import choose_and_execute
+from combat.engine.narration import (
+    render_dot_tick,
+    render_hazard_event,
+)
 from combat.loaders.abilities_loader import load_abilities
 from combat.loaders.ai_rules_loader import load_ai_rules
+from combat.loaders.narration_loader import load_narration
+from combat.loaders.status_effects_loader import load_status_effects
+from combat.loaders.hazards_loader import load_hazards
 
 
 def main():
     data_root = Path(__file__).parents[1] / "combat" / "data"
     abilities = load_abilities(data_root / "abilities.yaml")
-    rules = load_ai_rules(data_root / "ai_rules.yaml")
+    rules = load_ai_rules(data_root / "data" / "ai_rules.yaml")
+    narr = load_narration(data_root / "narration.yaml")
+    effs = load_status_effects(data_root / "status_effects.yaml")
+    hazards_cfg = load_hazards(data_root / "hazards.yaml")
 
     a = Combatant(
         "A",
         "Aria",
         {"ATT": 9, "DEX": 7, "ARM": 3, "WPN": 3},
-        hp=30.0,
+        hp=26.0,
         mana=6.0,
         resist={},
         tags=["humanoid"],
         team="alpha",
+        location="lava",
     )
     b = Combatant(
         "B",
@@ -29,38 +40,49 @@ def main():
         hp=28.0,
         mana=12.0,
         resist={"fire": 0.10},
-        tags=["humanoid"],
+        tags=["humanoid", "flying"],
         team="beta",
+        location="fountain",
     )
-    enc = Encounter([a, b], seed=888)
+    enc = Encounter([a, b], seed=909)
 
-    for round_idx in range(1, 7):
-        print(f"\n-- Round {round_idx} --")
-        # actor is next turn
-        actor = enc.next_turn()
-        # AI chooses and executes
-        outcome = choose_and_execute(enc.participants, actor, abilities, rules, enc.threat, enc.rng)
-        if outcome["ok"]:
-            # print summary
-            tgt_names = [
-                next((c.name for c in enc.participants if c.id == tid), tid)
-                for tid in outcome["target_ids"]
-            ]
-            print(f"{actor.name} uses {outcome['ability_id']} on {', '.join(tgt_names)}")
-            # update threat with resulting events
-            enc.ingest_events_update_threat(outcome["events"])
-        else:
-            print(f"{actor.name} has no ready rule/ability.")
+    for round_idx in range(1, 5):
+        print(f"\n== Round {round_idx} ==")
 
-        # Stop if one side dead
-        alphas = [c for c in enc.participants if c.team == "alpha" and c.is_alive()]
-        betas = [c for c in enc.participants if c.team == "beta" and c.is_alive()]
-        if not alphas or not betas:
-            winner = "alpha" if alphas else "beta"
-            print(f"\nWinner: {winner}")
-            break
+        # start_of_turn hazards + DoT tick + AI action for each actor
+        for _ in range(len(enc.participants)):
+            actor = enc.next_turn()
 
-    print(f"\nThreat (per victim→attacker): {enc.threat}")
+            # Hazards at start_of_turn
+            for ev in enc.process_hazards("start_of_turn"):
+                # Show only hazard lines
+                print("•", render_hazard_event(ev, hazards_cfg, enc.rng))
+
+            # Status DoTs
+            from combat.engine.effects import tick_start_of_turn
+
+            for ev in tick_start_of_turn(actor, effs, enc.rng):
+                print(
+                    "•",
+                    render_dot_tick(actor.name, ev["effect_id"], ev["amount"], effs, narr, enc.rng),
+                )
+
+            # AI action (using your rules)
+            outcome = choose_and_execute(
+                enc.participants, actor, abilities, rules, enc.threat, enc.rng
+            )
+            if outcome["ok"]:
+                enc.ingest_events_update_threat(outcome["events"])
+
+            # Hazards at end_of_turn
+            for ev in enc.process_hazards("end_of_turn"):
+                print("•", render_hazard_event(ev, hazards_cfg, enc.rng))
+
+        # (Optional) you could decrement finite hazard durations here if you add such hazards later.
+
+    print(
+        f"\nFinal → {a.name}: HP {a.hp:.1f}, Mana {a.mana:.1f} | {b.name}: HP {b.hp:.1f}, Mana {b.mana:.1f}"
+    )
 
 
 if __name__ == "__main__":

--- a/combat_package/scripts/run_battle_cli.py
+++ b/combat_package/scripts/run_battle_cli.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 from pathlib import Path
-from combat.engine.combatant import Combatant
-from combat.engine.encounter import Encounter
-from combat.engine.ai import choose_and_execute
-from combat.engine.narration import (
+from ..combat.engine.combatant import Combatant
+from ..combat.engine.encounter import Encounter
+from ..combat.engine.ai import choose_and_execute
+from ..combat.engine.narration import (
     render_dot_tick,
     render_hazard_event,
 )
-from combat.loaders.abilities_loader import load_abilities
-from combat.loaders.ai_rules_loader import load_ai_rules
-from combat.loaders.narration_loader import load_narration
-from combat.loaders.status_effects_loader import load_status_effects
-from combat.loaders.hazards_loader import load_hazards
+from ..combat.loaders.abilities_loader import load_abilities
+from ..combat.loaders.ai_rules_loader import load_ai_rules
+from ..combat.loaders.narration_loader import load_narration
+from ..combat.loaders.status_effects_loader import load_status_effects
+from ..combat.loaders.hazards_loader import load_hazards
 
 
 def main():
@@ -59,7 +59,7 @@ def main():
                 print("•", render_hazard_event(ev, hazards_cfg, enc.rng))
 
             # Status DoTs
-            from combat.engine.effects import tick_start_of_turn
+            from ..combat.engine.effects import tick_start_of_turn
 
             for ev in tick_start_of_turn(actor, effs, enc.rng):
                 print(

--- a/combat_package/tests/test_hazards_basic.py
+++ b/combat_package/tests/test_hazards_basic.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from pathlib import Path
+from combat.engine.combatant import Combatant
+from combat.engine.encounter import Encounter
+from combat.loaders.hazards_loader import load_hazards
+from combat.engine.narration import render_hazard_event
+
+
+def _hz_cfg():
+    return load_hazards(Path(__file__).parents[1] / "combat" / "data" / "hazards.yaml")
+
+
+def test_lava_damages_non_flying_in_lava_location():
+    a = Combatant(
+        "A",
+        "A",
+        {"INT": 0},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid"],
+        team="t1",
+        location="lava",
+    )
+    b = Combatant(
+        "B",
+        "B",
+        {"INT": 12},
+        hp=20.0,
+        mana=0.0,
+        resist={},
+        tags=["humanoid", "flying"],
+        team="t2",
+        location="lava",
+    )
+    enc = Encounter([a, b], seed=1)
+    evs = enc.process_hazards("start_of_turn")
+    # at least one hazard event for A; B is flying so should be skipped
+    targets = [
+        e["target_id"]
+        for e in evs
+        if e["type"] == "hazard" and e["hazard_id"] == "lava_zone" and e["kind"] == "damage"
+    ]
+    assert "A" in targets and "B" not in targets
+
+
+def test_fountain_heals_end_of_turn():
+    a = Combatant(
+        "A", "A", {}, hp=10.0, mana=0.0, resist={}, tags=[], team="t1", location="fountain"
+    )
+    enc = Encounter([a], seed=2)
+    evs = enc.process_hazards("end_of_turn")
+    heals = [e for e in evs if e["hazard_id"] == "healing_fountain" and e["kind"] == "heal"]
+    assert heals and heals[0]["amount"] > 0.0
+    assert a.hp > 10.0
+
+
+def test_hazard_narration_nonempty():
+    hz = _hz_cfg()
+    a = Combatant("A", "A", {}, hp=20.0, mana=0.0, resist={}, tags=[], team="t1", location="lava")
+    enc = Encounter([a], seed=3)
+    evs = enc.process_hazards("start_of_turn")
+    lines = [render_hazard_event(e, hz, enc.rng) for e in evs]
+    assert all(isinstance(x, str) and x for x in lines)
+
+
+def test_hazard_determinism_same_seed():
+    a1 = Combatant("A", "A", {}, hp=20.0, mana=0.0, resist={}, tags=[], team="t1", location="lava")
+    a2 = Combatant("A", "A", {}, hp=20.0, mana=0.0, resist={}, tags=[], team="t1", location="lava")
+    from combat.engine.encounter import Encounter
+
+    e1 = Encounter([a1], seed=42)
+    e2 = Encounter([a2], seed=42)
+    evs1 = e1.process_hazards("start_of_turn")
+    evs2 = e2.process_hazards("start_of_turn")
+
+    # amounts & kinds should match
+    def tpl(e):
+        return (e["hazard_id"], e["target_id"], e["kind"], e.get("amount", 0))
+
+    assert [tpl(x) for x in evs1] == [tpl(x) for x in evs2]


### PR DESCRIPTION
Combat branch 9: 

# combat_update_9 — Environment Hazards & Terrain (YAML-driven, deterministic, UI-agnostic)

ENV
- Use the **worldseed** interpreter (.venv), not “base”.

RECOVERY INSTRUCTION (if Cursor freezes mid-edit)
- Resume from the next ### HEADER in this prompt and continue.
- Overwrite files exactly as specified (idempotent writes).
- After finishing all sections, run the commands under “RUN & COMMIT”.

GOAL
Add a terrain/hazard system that:
- Loads **hazards** from YAML.
- Applies **effects at specific phases** (start_of_round, start_of_turn, end_of_turn).
- Supports **targeting filters** (by team, by location, by tags).
- Emits typed **events** (`hazard`) and uses RandomSource for determinism.
- Stays compatible with existing engine (no XP, UI-agnostic).

SCOPE (create/modify exactly these)
- NEW loader: `combat/loaders/hazards_loader.py`
- NEW data: `combat/data/hazards.yaml` (sample hazards)
- NEW engine module: `combat/engine/environment.py` (Environment orchestrator)
- PATCH: `combat/engine/combatant.py` (add `location` with default)
- PATCH: `combat/engine/encounter.py` (own Environment instance; call per phase)
- PATCH: `combat/engine/narration.py` (helper to render hazard events)
- CLI: update to demonstrate hazards live
- TESTS: hazard damage/heal; team/location/tag filters; duration & phase; determinism

──────────────────────────────────────────────────────────────────────────────
### LOADER — hazards

# combat_package/combat/loaders/hazards_loader.py
from __future__ import annotations
from pathlib import Path
import yaml

def load_hazards(path: str | Path) -> dict:
    p = Path(path)
    if not p.exists():
        return {"hazards": []}
    with open(p, "r", encoding="utf-8") as fh:
        data = yaml.safe_load(fh) or {}
    data.setdefault("hazards", [])
    return data

──────────────────────────────────────────────────────────────────────────────
### DATA — sample hazards

# combat_package/combat/data/hazards.yaml
hazards:
  - id: lava_zone
    name: "Lava Flow"
    phase: start_of_turn             # start_of_round | start_of_turn | end_of_turn
    targeting:
      locations: ["lava"]            # affect only units whose combatant.location in this set
      require_tag_absent: ["flying"] # skip targets with any of these tags
      team: any                      # any | alpha | beta (string match to combatant.team)
    duration_rounds: 0               # 0 = persistent
    effects:
      damage:
        amount: "4 + INT*0.0"
        damage_type: fire
      apply_status:
        - { id: burning, chance: 0.25 }
    narration:
      tick:
        - { text: "Lava spits at {target}, searing for {amount}.", weight: 2 }
        - { text: "{target} skirts molten stone ({amount}).", weight: 1 }

  - id: healing_fountain
    name: "Fountain of Renewal"
    phase: end_of_turn
    targeting:
      locations: ["fountain"]
      team: any
    duration_rounds: 0
    effects:
      heal:
        amount: 3
      resource:
        mana: 1
    narration:
      tick:
        - { text: "Cool waters mend {target} for {amount}.", weight: 2 }

──────────────────────────────────────────────────────────────────────────────
### ENGINE — combatant: add location

# combat_package/combat/engine/combatant.py
from __future__ import annotations
from dataclasses import dataclass, field
from typing import Dict, List

@dataclass
class Combatant:
    id: str
    name: str
    stats: Dict[str, float]
    hp: float
    mana: float
    resist: Dict[str, float] = field(default_factory=dict)
    tags: List[str] = field(default_factory=list)
    statuses: List[dict] = field(default_factory=list)
    cooldowns: Dict[str, int] = field(default_factory=dict)
    team: str = "neutral"
    inventory: Dict[str, int] = field(default_factory=dict)
    location: str = "arena"      # NEW: simple location label (for hazards/terrain)
    def is_alive(self) -> bool:
        return self.hp > 0

──────────────────────────────────────────────────────────────────────────────
### ENGINE — environment orchestrator

# combat_package/combat/engine/environment.py
from __future__ import annotations
from typing import Dict, Any, List, Optional
from .combatant import Combatant
from .rng import RandomSource
import ast

def _safe_eval(expr: str, ctx: Dict[str, float]) -> float:
    if not isinstance(expr, str): return float(expr)
    tree = ast.parse(expr, mode="eval")
    SAFE = (ast.Expression, ast.BinOp, ast.UnaryOp, ast.Num, ast.Constant, ast.Name, ast.Load, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.UAdd, ast.USub)
    def ev(n):
        if type(n) not in SAFE: raise ValueError("Unsafe")
        if isinstance(n, ast.Expression): return ev(n.body)
        if isinstance(n, ast.Num): return float(n.n)
        if isinstance(n, ast.Constant):
            if isinstance(n.value, (int, float)): return float(n.value)
            raise ValueError("bad const")
        if isinstance(n, ast.Name): return float(ctx.get(n.id, 0.0))
        if isinstance(n, ast.UnaryOp): 
            v = ev(n.operand); return +v if isinstance(n.op, ast.UAdd) else -v
        if isinstance(n, ast.BinOp):
            a, b = ev(n.left), ev(n.right)
            if isinstance(n.op, ast.Add): return a + b
            if isinstance(n.op, ast.Sub): return a - b
            if isinstance(n.op, ast.Mult): return a * b
            if isinstance(n.op, ast.Div): return a / b if b != 0 else 0.0
        raise ValueError("Unsupported")
    return float(ev(tree))

def _choice_weighted(rng: RandomSource, lines: List[dict]) -> str:
    if not lines: return ""
    pool = []
    for ln in lines:
        w = int(ln.get("weight", 1) or 1)
        pool.extend([ln.get("text","")] * max(1, w))
    return rng.choice(pool)

class Environment:
    """
    Applies hazard effects at configured phases.
    Keeps per-hazard remaining duration (rounds) if > 0.
    """
    def __init__(self, hazards_cfg: Dict[str, Any]):
        self.hazards = []
        for h in (hazards_cfg.get("hazards") or []):
            h = dict(h)
            dur = int(h.get("duration_rounds", 0) or 0)
            h["_remaining_rounds"] = dur
            self.hazards.append(h)

    def tick_round_boundary(self) -> None:
        """Call at start_of_round to decrement round-based durations AFTER the first round."""
        # We’ll decrement at the *end* of a full round in Encounter; for simplicity, leave here no-op.
        pass

    def process_phase(
        self,
        phase: str,
        participants: List[Combatant],
        rng: RandomSource,
    ) -> List[Dict[str, Any]]:
        """
        Returns a list of typed events for narration/logging:
          {"type":"hazard","hazard_id":..., "target_id":..., "kind":"damage|heal|resource|effect", "amount":float, "dtype":str|None}
        """
        events: List[Dict[str, Any]] = []
        for hz in list(self.hazards):
            if hz.get("phase") != phase:
                continue
            # duration check: 0 = persistent; if >0 and exhausted, skip
            if int(hz.get("_remaining_rounds", 0)) == 0 and int(hz.get("duration_rounds", 0)) > 0:
                continue
            t = hz.get("targeting") or {}
            locs = set(t.get("locations") or [])
            team = str(t.get("team","any"))
            absent = set(t.get("require_tag_absent") or [])
            # candidates
            cands = [c for c in participants if c.is_alive()]
            if locs:
                cands = [c for c in cands if c.location in locs]
            if team != "any":
                cands = [c for c in cands if c.team == team]
            if absent:
                cands = [c for c in cands if not any(tag in absent for tag in (c.tags or []))]

            eff = hz.get("effects") or {}
            for c in cands:
                # context: victim stats for scaling (safe)
                ctx = {
                    "STR": float(c.stats.get("STR", 0.0)),
                    "DEX": float(c.stats.get("DEX", 0.0)),
                    "INT": float(c.stats.get("INT", 0.0)),
                    "STA": float(c.stats.get("STA", 0.0)),
                }
                # damage
                if "damage" in eff:
                    spec = eff["damage"] or {}
                    amt = spec.get("amount", 0)
                    try:
                        val = max(0.0, _safe_eval(amt, ctx))
                    except Exception:
                        val = 0.0
                    dtype = spec.get("damage_type")
                    # apply resist
                    res = float(c.resist.get(dtype, 0.0)) if dtype else 0.0
                    val = round(val * (1.0 - max(0.0, min(1.0, res))), 1)
                    if val > 0:
                        c.hp = max(0.0, c.hp - val)
                        events.append({"type":"hazard","hazard_id":hz.get("id"),"target_id":c.id,"kind":"damage","amount":val,"dtype":dtype})
                # heal
                if "heal" in eff:
                    h = float(eff["heal"].get("amount", 0))
                    if h > 0:
                        c.hp = c.hp + h
                        events.append({"type":"hazard","hazard_id":hz.get("id"),"target_id":c.id,"kind":"heal","amount":h,"dtype":None})
                # resource (mana only for now)
                if "resource" in eff:
                    mp = float((eff["resource"] or {}).get("mana", 0))
                    if mp > 0:
                        c.mana = c.mana + mp
                        events.append({"type":"hazard","hazard_id":hz.get("id"),"target_id":c.id,"kind":"resource","amount":mp,"dtype":None})
                # apply_status
                for spec in (eff.get("apply_status") or []):
                    from .effects import apply_status
                    eid = spec.get("id"); chance = float(spec.get("chance", 1.0))
                    if eid and rng.randf() <= chance:
                        inst = apply_status(c, eid, {"effects":{}}, source_id=f"hazard:{hz.get('id')}")
                        if inst:
                            events.append({"type":"hazard","hazard_id":hz.get("id"),"target_id":c.id,"kind":"effect","effect_id":eid,"amount":0.0,"dtype":None})
            # duration bookkeeping for finite hazards: decrement per round at end_of_turn of last unit if needed (handled by Encounter)
        return events

──────────────────────────────────────────────────────────────────────────────
### ENGINE — narration helper for hazards

# combat_package/combat/engine/narration.py
# Append these helpers (do not remove existing functions)
from __future__ import annotations
from typing import Dict, Any
from .rng import RandomSource

def render_hazard_event(ev: Dict[str, Any], hazards_cfg: Dict[str, Any], rng: RandomSource) -> str:
    hz = next((h for h in (hazards_cfg.get("hazards") or []) if h.get("id")==ev.get("hazard_id")), {})
    lines = (hz.get("narration") or {}).get("tick", [])
    target = ev.get("target_id", "target")
    amount = ev.get("amount", 0)
    if lines:
        # simple uniform choice (weights baked into duplicates handled upstream if needed)
        pool = []
        for ln in lines:
            pool.extend([ln.get("text","")] * int(max(1, ln.get("weight", 1))))
        if pool:
            txt = rng.choice(pool)
            return txt.format(target=target, amount=int(amount) if abs(amount-round(amount))<1e-6 else f"{amount:.1f}")
    # fallback:
    if ev.get("kind") == "damage":
        return f"{ev.get('hazard_id')} harms {target} for {amount}."
    if ev.get("kind") == "heal":
        return f"{ev.get('hazard_id')} heals {target} for {amount}."
    if ev.get("kind") == "resource":
        return f"{target} regains {amount} mana from {ev.get('hazard_id')}."
    if ev.get("kind") == "effect":
        return f"{target} is affected by {ev.get('effect_id')}."
    return f"{ev.get('hazard_id')} affects {target}."

──────────────────────────────────────────────────────────────────────────────
### ENGINE — encounter integration

# combat_package/combat/engine/encounter.py
# Patch: hold Environment; call per phase; decrement finite hazard durations at end-of-round.
from __future__ import annotations
from typing import List, Dict, Any, Optional
from .combatant import Combatant
from .rng import RandomSource
from .threat import blank_table, add_threat, decay_all, normalize
from .environment import Environment
from ..loaders.hazards_loader import load_hazards
from pathlib import Path

class Encounter:
    def __init__(self, participants: List[Combatant], seed: int | None = 1234):
        if not participants: raise ValueError("Encounter requires at least one participant.")
        self.participants = list(participants)
        self.rng = RandomSource(seed)
        self._order = sorted(range(len(self.participants)),
                             key=lambda i: (-(self.participants[i].stats.get("DEX",0) or 0),
                                            self.participants[i].name.lower(),
                                            self.participants[i].id))
        self._ptr = 0
        self._round = 1
        self.log: List[str] = []
        self.events: List[Dict[str, Any]] = []
        self.threat = blank_table([c.id for c in self.participants])
        # NEW: environment
        data_root = Path(__file__).parents[2] / "data"
        self._hazards_cfg = load_hazards(data_root / "hazards.yaml")
        self.env = Environment(self._hazards_cfg)

    # ... existing methods (order_ids, next_turn, living, tick_cooldowns, snapshot/restore, ingest_events_update_threat, run_until) remain ...

    # NEW: process hazards at a given phase for given actor (actor can be None for round events)
    def process_hazards(self, phase: str) -> List[Dict[str, Any]]:
        evs = self.env.process_phase(phase, self.participants, self.rng)
        self.events.extend(evs)
        return evs

    # We call hazards at start_of_turn before DoT ticks; and at end_of_turn after actions.
    # If you want start_of_round hazards, you can call process_hazards("start_of_round") externally.

──────────────────────────────────────────────────────────────────────────────
### CLI — demonstrate hazards

# combat_package/scripts/run_battle_cli.py
from __future__ import annotations
from pathlib import Path
from combat.engine.combatant import Combatant
from combat.engine.encounter import Encounter
from combat.engine.ai import choose_and_execute
from combat.engine.narration import render_event, render_status_apply, render_dot_tick, render_hazard_event
from combat.loaders.abilities_loader import load_abilities
from combat.loaders.ai_rules_loader import load_ai_rules
from combat.loaders.narration_loader import load_narration
from combat.loaders.status_effects_loader import load_status_effects
from combat.loaders.hazards_loader import load_hazards

def main():
    data_root = Path(__file__).parents[1] / "combat" / "data"
    abilities = load_abilities(data_root / "abilities.yaml")
    rules = load_ai_rules(data_root / "ai_rules.yaml")
    narr = load_narration(data_root / "narration.yaml")
    effs = load_status_effects(data_root / "status_effects.yaml")
    hazards_cfg = load_hazards(data_root / "hazards.yaml")

    a = Combatant("A","Aria",{"ATT":9,"DEX":7,"ARM":3,"WPN":3},hp=26.0,mana=6.0,resist={},tags=["humanoid"],team="alpha",location="lava")
    b = Combatant("B","Belor",{"ATT":6,"DEX":8,"INT":12,"ARM":2,"WPN":1},hp=28.0,mana=12.0,resist={"fire":0.10},tags=["humanoid","flying"],team="beta",location="fountain")
    enc = Encounter([a,b], seed=909)

    for round_idx in range(1, 5):
        print(f"\n== Round {round_idx} ==")

        # start_of_turn hazards + DoT tick + AI action for each actor
        for _ in range(len(enc.participants)):
            actor = enc.next_turn()

            # Hazards at start_of_turn
            for ev in enc.process_hazards("start_of_turn"):
                # Show only hazard lines
                print("•", render_hazard_event(ev, hazards_cfg, enc.rng))

            # Status DoTs
            from combat.engine.effects import tick_start_of_turn
            for ev in tick_start_of_turn(actor, effs, enc.rng):
                print("•", render_dot_tick(actor.name, ev["effect_id"], ev["amount"], effs, narr, enc.rng))

            # AI action (using your rules)
            outcome = choose_and_execute(enc.participants, actor, abilities, rules, enc.threat, enc.rng)
            if outcome["ok"]:
                enc.ingest_events_update_threat(outcome["events"])

            # Hazards at end_of_turn
            for ev in enc.process_hazards("end_of_turn"):
                print("•", render_hazard_event(ev, hazards_cfg, enc.rng))

        # (Optional) you could decrement finite hazard durations here if you add such hazards later.

    print(f"\nFinal → {a.name}: HP {a.hp:.1f}, Mana {a.mana:.1f} | {b.name}: HP {b.hp:.1f}, Mana {b.mana:.1f}")

if __name__ == "__main__":
    main()

──────────────────────────────────────────────────────────────────────────────
### TESTS — hazards behavior

# combat_package/tests/test_hazards_basic.py
from __future__ import annotations
from pathlib import Path
from combat.engine.combatant import Combatant
from combat.engine.encounter import Encounter
from combat.loaders.hazards_loader import load_hazards
from combat.engine.narration import render_hazard_event

def _hz_cfg():
    return load_hazards(Path(__file__).parents[1] / "combat" / "data" / "hazards.yaml")

def test_lava_damages_non_flying_in_lava_location():
    hz = _hz_cfg()
    a = Combatant("A","A",{"INT":0},hp=20.0,mana=0.0,resist={},tags=["humanoid"],team="t1",location="lava")
    b = Combatant("B","B",{"INT":12},hp=20.0,mana=0.0,resist={},tags=["humanoid","flying"],team="t2",location="lava")
    enc = Encounter([a,b], seed=1)
    evs = enc.process_hazards("start_of_turn")
    # at least one hazard event for A; B is flying so should be skipped
    targets = [e["target_id"] for e in evs if e["type"]=="hazard" and e["hazard_id"]=="lava_zone" and e["kind"]=="damage"]
    assert "A" in targets and "B" not in targets

def test_fountain_heals_end_of_turn():
    hz = _hz_cfg()
    a = Combatant("A","A",{},hp=10.0,mana=0.0,resist={},tags=[],team="t1",location="fountain")
    enc = Encounter([a], seed=2)
    evs = enc.process_hazards("end_of_turn")
    heals = [e for e in evs if e["hazard_id"]=="healing_fountain" and e["kind"]=="heal"]
    assert heals and heals[0]["amount"] > 0.0
    assert a.hp > 10.0

def test_hazard_narration_nonempty():
    hz = _hz_cfg()
    a = Combatant("A","A",{},hp=20.0,mana=0.0,resist={},tags=[],team="t1",location="lava")
    enc = Encounter([a], seed=3)
    evs = enc.process_hazards("start_of_turn")
    lines = [render_hazard_event(e, hz, enc.rng) for e in evs]
    assert all(isinstance(x, str) and x for x in lines)

def test_hazard_determinism_same_seed():
    hz = _hz_cfg()
    a1 = Combatant("A","A",{},hp=20.0,mana=0.0,resist={},tags=[],team="t1",location="lava")
    a2 = Combatant("A","A",{},hp=20.0,mana=0.0,resist={},tags=[],team="t1",location="lava")
    from combat.engine.encounter import Encounter
    e1 = Encounter([a1], seed=42)
    e2 = Encounter([a2], seed=42)
    evs1 = e1.process_hazards("start_of_turn")
    evs2 = e2.process_hazards("start_of_turn")
    # amounts & kinds should match
    tpl = lambda e: (e["hazard_id"], e["target_id"], e["kind"], e.get("amount",0))
    assert [tpl(x) for x in evs1] == [tpl(x) for x in evs2]

──────────────────────────────────────────────────────────────────────────────
### ACCEPTANCE CRITERIA

1) **All previous tests still pass.**

2) **New tests pass:**
   - `tests/test_hazards_basic.py::test_lava_damages_non_flying_in_lava_location`
   - `tests/test_hazards_basic.py::test_fountain_heals_end_of_turn`
   - `tests/test_hazards_basic.py::test_hazard_narration_nonempty`
   - `tests/test_hazards_basic.py::test_hazard_determinism_same_seed`

3) **Engine behavior:**
   - `Encounter.process_hazards(phase)` returns typed `hazard` events; applying damage/heal/resource/status accordingly.
   - Phase handling works for at least `start_of_turn` and `end_of_turn`.
   - Targeting filters work:
     - `locations` matches `Combatant.location`.
     - `team` accepts `"any"`, `"alpha"`, `"beta"` (or any team label you use).
     - `require_tag_absent` excludes units with listed tags (e.g., `"flying"`).
   - Damage respects target **resist** for the hazard’s `damage_type`.
   - All randomness goes through `RandomSource`.

4) **Modularity & Safety:**
   - No UI imports; no XP logic.
   - YAML-first; missing `hazards.yaml` yields no hazards and no crashes.
   - Safe expression evaluation for numeric formulas.

5) **CLI demo:**
   - `scripts/run_battle_cli.py` prints hazard lines on phases and finishes with final HP/mana.

──────────────────────────────────────────────────────────────────────────────
### RUN & COMMIT (one-liners)

Windows PowerShell:
`.\.venv\Scripts\Activate.ps1; pip install -e ".[dev]"; pre-commit run --all-files; pytest -q; python scripts/run_battle_cli.py; git add -A; git commit -m "combat_update_9: environment hazards & terrain backend"; git push`

macOS/Linux:
`source .venv/bin/activate && pip install -e ".[dev]" && pre-commit run --all-files && pytest -q && python scripts/run_battle_cli.py && git add -A && git commit -m "combat_update_9: environment hazards & terrain backend" && git push`

CONSTRAINTS
- Keep all changes additive/backward-compatible.
- Deterministic behavior under fixed seeds.
- Keep engine textual and modular for future UI/agent integration.
